### PR TITLE
don't run pedal calib on x86

### DIFF
--- a/projects/pedal_board/rules.mk
+++ b/projects/pedal_board/rules.mk
@@ -8,6 +8,10 @@
 # Specify the libraries you want to include
 $(T)_DEPS := ms-helper ms-common codegen-tooling
 
+ifeq (x86,$(PLATFORM))
+$(T)_EXCLUDE_TESTS := pedal_calib
+endif
+
 $(T)_test_brake_data_MOCKS := ads1015_read_raw
 
 $(T)_test_throttle_data_MOCKS := ads1015_read_raw


### PR DESCRIPTION
Pedal calib increases test length and is not actually a test, so we shouldn't run it on x86