### PR TITLE
[SOFT-206] Implement data_store solar module

### DIFF
--- a/projects/solar/inc/data_store.h
+++ b/projects/solar/inc/data_store.h
@@ -2,6 +2,8 @@
 
 // Stores all data collected by solar.
 // Requires the event queue to be initialized.
+// Note that on startup, all data will be garbage, so data consumers must only read data after
+// receiving a DATA_READY_EVENT.
 
 #include <stdint.h>
 #include "status.h"
@@ -66,7 +68,8 @@ typedef enum {
 StatusCode data_store_enter(DataPoint data_point, uint16_t value);
 
 // Call this when you're done a session of calling |data_store_enter| and you want data consumers
-// to be notified. Raises a DATA_READY_EVENT.
+// to be notified. Raises a DATA_READY_EVENT. Every data point should have been overwritten from
+// its initial garbage when this is called.
 StatusCode data_store_done(void);
 
 // Puts the value of the data point in |value|.

--- a/projects/solar/inc/data_store.h
+++ b/projects/solar/inc/data_store.h
@@ -65,9 +65,9 @@ typedef enum {
 } DataPoint;
 
 // Overwrites the value of the data point with |value|.
-StatusCode data_store_enter(DataPoint data_point, uint16_t value);
+StatusCode data_store_set(DataPoint data_point, uint16_t value);
 
-// Call this when you're done a session of calling |data_store_enter| and you want data consumers
+// Call this when you're done a session of calling |data_store_set| and you want data consumers
 // to be notified. Raises a DATA_READY_EVENT. Every data point should have been overwritten from
 // its initial garbage when this is called.
 StatusCode data_store_done(void);

--- a/projects/solar/inc/data_store.h
+++ b/projects/solar/inc/data_store.h
@@ -14,10 +14,10 @@ typedef enum {
   DATA_POINT_VOLTAGE_4,
   DATA_POINT_VOLTAGE_5,
   DATA_POINT_VOLTAGE_6,
-  
+
   // Current from the current sense MCP3427
   DATA_POINT_CURRENT,
-  
+
   // Temperatures from the thermistors
   DATA_POINT_TEMPERATURE_1,
   DATA_POINT_TEMPERATURE_2,
@@ -25,7 +25,7 @@ typedef enum {
   DATA_POINT_TEMPERATURE_4,
   DATA_POINT_TEMPERATURE_5,
   DATA_POINT_TEMPERATURE_6,
-  
+
   // MPPT input currents
   DATA_POINT_MPPT_CURRENT_1,
   DATA_POINT_MPPT_CURRENT_2,
@@ -33,7 +33,7 @@ typedef enum {
   DATA_POINT_MPPT_CURRENT_4,
   DATA_POINT_MPPT_CURRENT_5,
   DATA_POINT_MPPT_CURRENT_6,
-  
+
   // MPPT input voltages
   DATA_POINT_MPPT_VOLTAGE_1,
   DATA_POINT_MPPT_VOLTAGE_2,
@@ -41,7 +41,7 @@ typedef enum {
   DATA_POINT_MPPT_VOLTAGE_4,
   DATA_POINT_MPPT_VOLTAGE_5,
   DATA_POINT_MPPT_VOLTAGE_6,
-  
+
   // MPPT current PWM duty cycles, out of 1000
   DATA_POINT_MPPT_PWM_1,
   DATA_POINT_MPPT_PWM_2,
@@ -49,16 +49,25 @@ typedef enum {
   DATA_POINT_MPPT_PWM_4,
   DATA_POINT_MPPT_PWM_5,
   DATA_POINT_MPPT_PWM_6,
-  
-  NUM_DATA_POINT_POINTS,
+
+  // The CR bits on the MPPTS: we don't know what they are, but let's keep track of them for now
+  // Value of the data points will be 0 or 1
+  DATA_POINT_CR_BIT_1,
+  DATA_POINT_CR_BIT_2,
+  DATA_POINT_CR_BIT_3,
+  DATA_POINT_CR_BIT_4,
+  DATA_POINT_CR_BIT_5,
+  DATA_POINT_CR_BIT_6,
+
+  NUM_DATA_POINTS,
 } DataPoint;
 
-// Overwrite the value of the data point with |value|.
+// Overwrites the value of the data point with |value|.
 StatusCode data_store_enter(DataPoint data_point, uint16_t value);
 
 // Call this when you're done a session of calling |data_store_enter| and you want data consumers
 // to be notified. Raises a DATA_READY_EVENT.
 StatusCode data_store_done(void);
 
-// Put the value of the data point in |value|.
+// Puts the value of the data point in |value|.
 StatusCode data_store_get(DataPoint data_point, uint16_t *value);

--- a/projects/solar/inc/data_store.h
+++ b/projects/solar/inc/data_store.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// Stores all data collected by solar.
+// Requires the event queue to be initialized.
+
+#include <stdint.h>
+#include "status.h"
+
+typedef enum {
+  // Voltages from the voltage sense MCP3427s
+  DATA_POINT_VOLTAGE_1 = 0,
+  DATA_POINT_VOLTAGE_2,
+  DATA_POINT_VOLTAGE_3,
+  DATA_POINT_VOLTAGE_4,
+  DATA_POINT_VOLTAGE_5,
+  DATA_POINT_VOLTAGE_6,
+  
+  // Current from the current sense MCP3427
+  DATA_POINT_CURRENT,
+  
+  // Temperatures from the thermistors
+  DATA_POINT_TEMPERATURE_1,
+  DATA_POINT_TEMPERATURE_2,
+  DATA_POINT_TEMPERATURE_3,
+  DATA_POINT_TEMPERATURE_4,
+  DATA_POINT_TEMPERATURE_5,
+  DATA_POINT_TEMPERATURE_6,
+  
+  // MPPT input currents
+  DATA_POINT_MPPT_CURRENT_1,
+  DATA_POINT_MPPT_CURRENT_2,
+  DATA_POINT_MPPT_CURRENT_3,
+  DATA_POINT_MPPT_CURRENT_4,
+  DATA_POINT_MPPT_CURRENT_5,
+  DATA_POINT_MPPT_CURRENT_6,
+  
+  // MPPT input voltages
+  DATA_POINT_MPPT_VOLTAGE_1,
+  DATA_POINT_MPPT_VOLTAGE_2,
+  DATA_POINT_MPPT_VOLTAGE_3,
+  DATA_POINT_MPPT_VOLTAGE_4,
+  DATA_POINT_MPPT_VOLTAGE_5,
+  DATA_POINT_MPPT_VOLTAGE_6,
+  
+  // MPPT current PWM duty cycles, out of 1000
+  DATA_POINT_MPPT_PWM_1,
+  DATA_POINT_MPPT_PWM_2,
+  DATA_POINT_MPPT_PWM_3,
+  DATA_POINT_MPPT_PWM_4,
+  DATA_POINT_MPPT_PWM_5,
+  DATA_POINT_MPPT_PWM_6,
+  
+  NUM_DATA_POINT_POINTS,
+} DataPoint;
+
+// Overwrite the value of the data point with |value|.
+StatusCode data_store_enter(DataPoint data_point, uint16_t value);
+
+// Call this when you're done a session of calling |data_store_enter| and you want data consumers
+// to be notified. Raises a DATA_READY_EVENT.
+StatusCode data_store_done(void);
+
+// Put the value of the data point in |value|.
+StatusCode data_store_get(DataPoint data_point, uint16_t *value);

--- a/projects/solar/inc/solar_events.h
+++ b/projects/solar/inc/solar_events.h
@@ -2,6 +2,9 @@
 
 // Defines events used in solar.
 
+#define DATA_READY_EVENT_PRIORITY EVENT_PRIORITY_NORMAL
+#define FAULT_EVENT_PRIORITY EVENT_PRIORITY_HIGH
+
 typedef enum {
   SOLAR_CAN_EVENT_RX = 0,
   SOLAR_CAN_EVENT_TX,
@@ -14,4 +17,4 @@ typedef enum {
   NUM_SOLAR_DATA_EVENTS,
 } SolarDataEvent;
 
-// TODO(SOFT-211,SOFT-215) Define fault events
+// TODO(SOFT-215): Define fault events

--- a/projects/solar/inc/solar_events.h
+++ b/projects/solar/inc/solar_events.h
@@ -1,0 +1,17 @@
+#pragma once
+
+// Defines events used in solar.
+
+typedef enum {
+  SOLAR_CAN_EVENT_RX = 0,
+  SOLAR_CAN_EVENT_TX,
+  SOLAR_CAN_EVENT_FAULT,
+  NUM_SOLAR_CAN_EVENTS,
+} SolarCanEvent;
+
+typedef enum {
+  DATA_READY_EVENT = NUM_SOLAR_CAN_EVENTS + 1,
+  NUM_SOLAR_DATA_EVENTS,
+} SolarDataEvent;
+
+// TODO(SOFT-211,SOFT-215) Define fault events

--- a/projects/solar/rules.mk
+++ b/projects/solar/rules.mk
@@ -1,0 +1,9 @@
+# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
+# Pre-defined:
+# $(T)_SRC_ROOT: $(T)_DIR/src
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
+
+# Specify the libraries you want to include
+$(T)_DEPS := ms-common

--- a/projects/solar/src/data_store.c
+++ b/projects/solar/src/data_store.c
@@ -4,7 +4,7 @@
 
 static uint16_t s_data_store[NUM_DATA_POINTS];
 
-StatusCode data_store_enter(DataPoint data_point, uint16_t value) {
+StatusCode data_store_set(DataPoint data_point, uint16_t value) {
   if (data_point >= NUM_DATA_POINTS) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -18,7 +18,7 @@ StatusCode data_store_done(void) {
 }
 
 StatusCode data_store_get(DataPoint data_point, uint16_t *value) {
-  if (!value || data_point >= NUM_DATA_POINTS) {
+  if (value == NULL || data_point >= NUM_DATA_POINTS) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
   *value = s_data_store[data_point];

--- a/projects/solar/src/data_store.c
+++ b/projects/solar/src/data_store.c
@@ -2,8 +2,6 @@
 #include "event_queue.h"
 #include "solar_events.h"
 
-#define DATA_READY_PRIORITY EVENT_PRIORITY_NORMAL
-
 static uint16_t s_data_store[NUM_DATA_POINTS];
 
 StatusCode data_store_enter(DataPoint data_point, uint16_t value) {
@@ -16,7 +14,7 @@ StatusCode data_store_enter(DataPoint data_point, uint16_t value) {
 
 StatusCode data_store_done(void) {
   // the data ready event has no associated data
-  return event_raise_priority(DATA_READY_PRIORITY, DATA_READY_EVENT, 0);
+  return event_raise_priority(DATA_READY_EVENT_PRIORITY, DATA_READY_EVENT, 0);
 }
 
 StatusCode data_store_get(DataPoint data_point, uint16_t *value) {

--- a/projects/solar/src/data_store.c
+++ b/projects/solar/src/data_store.c
@@ -1,0 +1,28 @@
+#include "data_store.h"
+#include "event_queue.h"
+#include "solar_events.h"
+
+#define DATA_READY_PRIORITY EVENT_PRIORITY_NORMAL
+
+static uint16_t s_data_store[NUM_DATA_POINTS];
+
+StatusCode data_store_enter(DataPoint data_point, uint16_t value) {
+  if (data_point >= NUM_DATA_POINTS) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  s_data_store[data_point] = value;
+  return STATUS_CODE_OK;
+}
+
+StatusCode data_store_done(void) {
+  // the data ready event has no associated data
+  return event_raise_priority(DATA_READY_PRIORITY, DATA_READY_EVENT, 0);
+}
+
+StatusCode data_store_get(DataPoint data_point, uint16_t *value) {
+  if (!value || data_point >= NUM_DATA_POINTS) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  *value = s_data_store[data_point];
+  return STATUS_CODE_OK;
+}

--- a/projects/solar/src/main.c
+++ b/projects/solar/src/main.c
@@ -1,0 +1,2 @@
+// Placeholder so the build doesn't fail
+int main(void) {}

--- a/projects/solar/test/test_data_store.c
+++ b/projects/solar/test/test_data_store.c
@@ -11,32 +11,38 @@ void setup_test(void) {
 }
 void teardown_test(void) {}
 
-// Test that we can enter and retrieve a value from the data store.
-void test_data_store_enter_and_get_basic(void) {
+// Test that we can set and get a value from the data store.
+void test_data_store_set_and_get_basic(void) {
   uint16_t value;
-  TEST_ASSERT_OK(data_store_enter(DATA_POINT_VOLTAGE_1, 0x1337));
+  TEST_ASSERT_OK(data_store_set(DATA_POINT_VOLTAGE_1, 0x1337));
   TEST_ASSERT_OK(data_store_get(DATA_POINT_VOLTAGE_1, &value));
   TEST_ASSERT_EQUAL(0x1337, value);
 }
 
 // Test that every data point works.
-void test_data_store_enter_and_get_thorough(void) {
+void test_data_store_set_and_get_thorough(void) {
   uint16_t value;
   for (DataPoint data_point = 0; data_point < NUM_DATA_POINTS; data_point++) {
-    TEST_ASSERT_OK(data_store_enter(data_point, 0xDEAD));
+    TEST_ASSERT_OK(data_store_set(data_point, 0xDEAD));
     TEST_ASSERT_OK(data_store_get(data_point, &value));
     TEST_ASSERT_EQUAL(0xDEAD, value);
   }
 }
 
-// Test that |data_store_enter| responds correctly on an invalid index.
-void test_data_store_enter_invalid_index(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
+// Test that |data_store_set| responds correctly on an invalid index.
+void test_data_store_set_invalid_index(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_set(NUM_DATA_POINTS, 0));
 }
 
 // Test that |data_store_get| responds correctly on an invalid index.
 void test_data_store_get_invalid_index(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
+  uint16_t value;
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_get(NUM_DATA_POINTS, &value));
+}
+
+// Test that |data_store_get| responds correctly on a null pointer.
+void test_data_store_get_null_pointer(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_get(DATA_POINT_VOLTAGE_1, NULL));
 }
 
 // Test that |data_store_done| correctly raises DATA_READY_EVENTs.

--- a/projects/solar/test/test_data_store.c
+++ b/projects/solar/test/test_data_store.c
@@ -34,12 +34,12 @@ void test_data_store_enter_invalid_index(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
 }
 
-// Test that |data_store_get| responds correclty on an invalid index.
+// Test that |data_store_get| responds correctly on an invalid index.
 void test_data_store_get_invalid_index(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
 }
 
-// Test that |data_store_done| correclty raises DATA_READY_EVENTs.
+// Test that |data_store_done| correctly raises DATA_READY_EVENTs.
 void test_data_store_done_raises_events(void) {
   Event e;
   MS_TEST_HELPER_ASSERT_NO_EVENT_RAISED();

--- a/projects/solar/test/test_data_store.c
+++ b/projects/solar/test/test_data_store.c
@@ -1,0 +1,49 @@
+#include "data_store.h"
+#include "event_queue.h"
+#include "log.h"
+#include "ms_test_helpers.h"
+#include "solar_events.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+void setup_test(void) {
+  event_queue_init();
+}
+void teardown_test(void) {}
+
+// Test that we can enter and retrieve a value from the data store.
+void test_data_store_enter_and_get_basic(void) {
+  uint16_t value;
+  TEST_ASSERT_OK(data_store_enter(DATA_POINT_VOLTAGE_1, 0x1337));
+  TEST_ASSERT_OK(data_store_get(DATA_POINT_VOLTAGE_1, &value));
+  TEST_ASSERT_EQUAL(0x1337, value);
+}
+
+// Test that every data point works.
+void test_data_store_enter_and_get_thorough(void) {
+  uint16_t value;
+  for (DataPoint data_point = 0; data_point < NUM_DATA_POINTS; data_point++) {
+    TEST_ASSERT_OK(data_store_enter(data_point, 0xDEAD));
+    TEST_ASSERT_OK(data_store_get(data_point, &value));
+    TEST_ASSERT_EQUAL(0xDEAD, value);
+  }
+}
+
+// Test that |data_store_enter| responds correctly on an invalid index.
+void test_data_store_enter_invalid_index(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
+}
+
+// Test that |data_store_get| responds correclty on an invalid index.
+void test_data_store_get_invalid_index(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, data_store_enter(NUM_DATA_POINTS, 0));
+}
+
+// Test that |data_store_done| correclty raises DATA_READY_EVENTs.
+void test_data_store_done_raises_events(void) {
+  Event e;
+  MS_TEST_HELPER_ASSERT_NO_EVENT_RAISED();
+  TEST_ASSERT_OK(data_store_done());
+  MS_TEST_HELPER_ASSERT_EVENT(e, DATA_READY_EVENT, 0);
+  MS_TEST_HELPER_ASSERT_NO_EVENT_RAISED();
+}


### PR DESCRIPTION
`data_store` provides an abstraction layer between reading the data and doing something with it. It stores all of the data collected by sense et al., then raises a `DATA_READY_EVENT`. Consumers of the data (`logger`, `fault_monitor`, etc) can retrieve the data directly from `data_store` to avoid overloading the event queue. All data is stored as `uint16_t`.

To store and retrieve data, we use a `DataPoint` enum with one entry for each data point we need (e.g. `DATA_POINT_VOLTAGE_1`, `DATA_POINT_MPPT_CURRENT_3`, etc.).

The `data_store_enter()` function takes a `DataPoint` parameter to identify which data point it is, as well as the data point as a `uint16_t`. It overwrites that data point in the module’s storage.

The `data_store_done()` function will be called by `sense` after a batch of data is read. It raises a `DATA_READY_EVENT` which will be received by the consumers of the data.

The `data_store_get()` function takes a `DataPoint` parameter and a `uint16_t*` and sets the pointer to the value of the data point.