### PR TITLE
[SOFT-240] Implement deterministic soft timers

### DIFF
--- a/libraries/libcore/inc/test_helpers.h
+++ b/libraries/libcore/inc/test_helpers.h
@@ -11,3 +11,96 @@
 
 // Mocking
 #define TEST_MOCK(func) __attribute__((used)) __wrap_##func
+
+// Add '#define DETERMINISTIC_SOFT_TIMERS' to the top of your test file
+// as well as the appropriate mocks in the makefile to use.
+// WARNING: Has issues if your code uses critical sections.
+#ifdef DETERMINISTIC_SOFT_TIMERS
+
+#include <string.h>
+
+#include "delay.h"
+#include "soft_timer.h"
+
+typedef struct DeterministicTimer {
+  SoftTimerCallback callback;
+  void *context;
+  bool inuse;
+  uint32_t time_remaining;
+} DeterministicTimer;
+
+// indexed by SoftTimerId
+static DeterministicTimer s_timers[SOFT_TIMER_MAX_TIMERS];
+static uint8_t s_active_timers = 0;
+
+void prv_trigger_timer(DeterministicTimer *timer, SoftTimerId timer_id) {
+  timer->callback(timer_id, timer->context);
+  memset(timer, 0, sizeof(*timer));
+  s_active_timers--;
+}
+
+void prv_timers_tick(void) {
+  for (SoftTimerId i = 0; i < SOFT_TIMER_MAX_TIMERS; i++) {
+    if (s_timers[i].inuse) {
+      s_timers[i].time_remaining--;
+      if (s_timers[i].time_remaining == 0) {
+        prv_trigger_timer(&s_timers[i], i);
+      }
+    }
+  }
+}
+
+StatusCode TEST_MOCK(soft_timer_start)(uint32_t duration_us, SoftTimerCallback callback,
+                                       void *context, SoftTimerId *timer_id) {
+  if (duration_us < SOFT_TIMER_MIN_TIME_US) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Soft timer too short!");
+  }
+
+  for (SoftTimerId i = 0; i < SOFT_TIMER_MAX_TIMERS; i++) {
+    if (s_timers[i].inuse == false) {
+      s_timers[i].callback = callback;
+      s_timers[i].context = context;
+      s_timers[i].time_remaining = duration_us;
+      s_timers[i].inuse = true;
+
+      if (timer_id != NULL) {
+        *timer_id = i;
+      }
+      s_active_timers++;
+      return STATUS_CODE_OK;
+    }
+  }
+
+  return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "Out of software timers.");
+}
+
+bool TEST_MOCK(soft_timer_cancel)(SoftTimerId timer_id) {
+  if (timer_id < SOFT_TIMER_MAX_TIMERS) {
+    if (s_timers[timer_id].inuse == true) {
+      memset(&s_timers[timer_id], 0, sizeof(s_timers[timer_id]));
+      s_active_timers--;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool TEST_MOCK(soft_timer_inuse)(void) {
+  if (s_active_timers > 0) {
+    return true;
+  }
+  return false;
+}
+
+void TEST_MOCK(soft_timer_init)(void) {
+  s_active_timers = 0;
+  memset(&s_timers[0], 0, sizeof(s_timers));
+}
+
+void TEST_MOCK(delay_us)(uint32_t t) {
+  for (uint32_t i = 0; i < t; i++) {
+    prv_timers_tick();
+  }
+}
+
+#endif

--- a/libraries/ms-helper/rules.mk
+++ b/libraries/ms-helper/rules.mk
@@ -9,7 +9,10 @@
 $(T)_DEPS := ms-common
 
 ifeq (x86,$(PLATFORM))
-$(T)_EXCLUDE_TESTS := mcp2515 adc_periodic_reader
+$(T)_EXCLUDE_TESTS := mcp2515
 endif
 
+FAKE_TIMERS = soft_timer_start soft_timer_cancel soft_timer_inuse soft_timer_init delay_us
+
 $(T)_test_thermistor_MOCKS := adc_read_converted adc_get_channel adc_set_channel
+$(T)_test_adc_periodic_reader_MOCKS := $(FAKE_TIMERS)

--- a/libraries/ms-helper/test/test_adc_periodic_reader.c
+++ b/libraries/ms-helper/test/test_adc_periodic_reader.c
@@ -1,3 +1,4 @@
+#define DETERMINISTIC_SOFT_TIMERS
 #include "adc.h"
 #include "adc_periodic_reader.h"
 #include "delay.h"
@@ -46,8 +47,8 @@ void setup_test(void) {
   interrupt_init();
   gpio_it_init();
   soft_timer_init();
-  adc_periodic_reader_init(TIMER_INTERVAL_MS);
   adc_init(ADC_MODE_SINGLE);
+  adc_periodic_reader_init(TIMER_INTERVAL_MS);
 }
 
 void test_adc_periodic_reader_test_callback() {


### PR DESCRIPTION
Running tests takes valuable developer time, which we want
to minimize. To reduce it, we can mock the passing of time
with counters rather than actual timers.

This commit implements these counters as well as adds them
to a sample test, adc_periodic_reader, to demonstrate
functionality. Also made a slight fix to the test since
it was previously broken by the x86 implementation of adc.c.