### PR TITLE
[SOFT-251] Run something in mpxe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@
 PROJ_DIR := projects
 PLATFORMS_DIR := platform
 LIB_DIR := libraries
+MPXE_DIR := mpxe
 MAKE_DIR := make
 
 PLATFORM ?= stm32f0xx
@@ -43,6 +44,9 @@ include $(MAKE_DIR)/filter.mk
 
 # Location of project
 PROJECT_DIR := $(PROJ_DIR)/$(PROJECT)
+
+# Location of piece
+PIECE_DIR := $(MPXE_DIR)/$(PIECE)
 
 # Location of platform
 PLATFORM_DIR := $(PLATFORMS_DIR)/$(PLATFORM)
@@ -66,6 +70,10 @@ else
 TARGET_BINARY = $(BIN_DIR)/test/$(LIBRARY)$(PROJECT)/test_$(TEST)_runner$(PLATFORM_EXT)
 endif
 
+ifneq (,$(PIECE))
+MPXE_BINARY = $(BIN_DIR)/$(PIECE)$(PLATFORM_EXT)
+endif
+
 DIRS := $(BUILD_DIR) $(BIN_DIR) $(STATIC_LIB_DIR) $(OBJ_CACHE)
 COMMA := ,
 
@@ -86,6 +94,14 @@ endef
 define include_proj
 $(eval TARGET := $(1));
 $(eval TARGET_TYPE := PROJ);
+$(eval include $(MAKE_DIR)/build.mk);
+$(eval undefine TARGET; undefine TARGET_TYPE)
+endef
+
+# $(call include_piece,piecename)
+define include_piec
+$(eval TARGET := $(1));
+$(eval TARGET_TYPE := MPXE);
 $(eval include $(MAKE_DIR)/build.mk);
 $(eval undefine TARGET; undefine TARGET_TYPE)
 endef
@@ -127,23 +143,26 @@ $(foreach lib,$(VALID_LIBRARIES),$(call include_lib,$(lib)))
 # Includes all projects so make can find their targets
 $(foreach proj,$(VALID_PROJECTS),$(call include_proj,$(proj)))
 
+# Includes all pieces so make can find their targets
+$(foreach piec,$(VALID_PIECES),$(call include_piec,$(piec)))
+
 IGNORE_CLEANUP_LIBS := CMSIS FreeRTOS STM32F0xx_StdPeriph_Driver unity FatFs
 FIND_PATHS := $(addprefix -o -path $(LIB_DIR)/,$(IGNORE_CLEANUP_LIBS))
-FIND := find $(PROJ_DIR) $(LIB_DIR) \
+FIND := find $(PROJ_DIR) $(LIB_DIR) $(MPXE_DIR)\
 			  \( $(wordlist 2,$(words $(FIND_PATHS)),$(FIND_PATHS)) \) -prune -o \
 				-iname "*.[ch]" -print
 
 # Lints libraries and projects, excludes IGNORE_CLEANUP_LIBS
 .PHONY: lint
 lint:
-	@echo "Linting *.[ch] in $(PROJ_DIR), $(LIB_DIR)"
+	@echo "Linting *.[ch] in $(PROJ_DIR), $(LIB_DIR), $(MPXE_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
 	@$(FIND) | xargs -r python2 lint.py
 
 # Disable import error
 .PHONY: pylint
 pylint:
-	@echo "Linting *.py in $(MAKE_DIR), $(PLATFORMS_DIR), $(PROJ_DIR), $(LIB_DIR)"
+	@echo "Linting *.py in $(MAKE_DIR), $(PLATFORMS_DIR), $(PROJ_DIR), $(LIB_DIR), $(MPXE_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
 	@find $(MAKE_DIR) $(PLATFORMS_DIR) -iname "*.py" -print | xargs -r pylint --disable=F0401 --disable=duplicate-code
 	@$(FIND:"*.[ch]"="*.py") | xargs -r pylint --disable=F0401 --disable=duplicate-code
@@ -151,7 +170,7 @@ pylint:
 # Formats libraries and projects, excludes IGNORE_CLEANUP_LIBS
 .PHONY: format
 format:
-	@echo "Formatting *.[ch] in $(PROJ_DIR), $(LIB_DIR)"
+	@echo "Formatting *.[ch] in $(PROJ_DIR), $(LIB_DIR), $(MPXE_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
 	@$(FIND) | xargs -r clang-format -i -style=file
 
@@ -164,8 +183,10 @@ test_format: format
 .PHONY: build
 ifneq (,$(PROJECT)$(TEST))
 build: $(TARGET_BINARY)
-else
+else ifneq (,$(LIBRARY))
 build: $(STATIC_LIB_DIR)/lib$(LIBRARY).a
+else ifneq (,$(PIECE))
+build: $(MPXE_BINARY)
 endif
 
 # Assumes that all libraries are used and will be built along with the projects

--- a/libraries/libcore/inc/log.h
+++ b/libraries/libcore/inc/log.h
@@ -23,9 +23,19 @@ typedef enum {
 #define LOG_WARN(fmt, ...) LOG(LOG_LEVEL_WARN, fmt, ##__VA_ARGS__)
 #define LOG_CRITICAL(fmt, ...) LOG(LOG_LEVEL_CRITICAL, fmt, ##__VA_ARGS__)
 
+#ifndef MPXE
 #define LOG(level, fmt, ...)                                                  \
   do {                                                                        \
     if ((level) >= LOG_LEVEL_VERBOSITY) {                                     \
       printf("[%u] %s:%u: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
     }                                                                         \
   } while (0)
+#else
+#define LOG(level, fmt, ...)                                                  \
+  do {                                                                        \
+    if ((level) >= LOG_LEVEL_VERBOSITY) {                                     \
+      printf("[%u] %s:%u: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
+      fflush(stdout);                                                         \
+    }                                                                         \
+  } while (0)
+#endif

--- a/make/build.mk
+++ b/make/build.mk
@@ -4,7 +4,7 @@
 
 # Alias target so we don't have super long variable names
 T := $(TARGET)
-ifeq (,$(filter LIB PROJ,$(TARGET_TYPE)))
+ifeq (,$(filter LIB PROJ MPXE,$(TARGET_TYPE)))
   $(error Invalid build target type for $(TARGET))
 endif
 

--- a/make/filter.mk
+++ b/make/filter.mk
@@ -1,4 +1,5 @@
 VALID_PROJECTS := $(patsubst $(PROJ_DIR)/%/rules.mk,%,$(wildcard $(PROJ_DIR)/*/rules.mk))
+VALID_PIECES += $(patsubst $(MPXE_DIR)/%/rules.mk,%,$(wildcard $(MPXE_DIR)/*/rules.mk))
 VALID_PLATFORMS := $(patsubst $(PLATFORMS_DIR)/%/platform.mk,%,$(wildcard $(PLATFORMS_DIR)/*/platform.mk))
 VALID_LIBRARIES := $(patsubst $(LIB_DIR)/%/rules.mk,%,$(wildcard $(LIB_DIR)/*/rules.mk))
 
@@ -13,7 +14,7 @@ ifneq (,$(filter clean lint pylint format build_all test_all test_format socketc
   # Universal operation: do nothing - args are not used or only PLATFORM is checked
 else ifneq (,$(filter new,$(MAKECMDGOALS)))
   # New project: just make sure PROJECT or LIBRARY is defined
-  ifeq (,$(PROJECT)$(LIBRARY))
+  ifeq (,$(PROJECT)$(LIBRARY)$(PIECE))
     $(error Missing project or library name. Expected PROJECT=... or LIBRARY=...)
   endif
 
@@ -25,8 +26,9 @@ else
   # Test/GDB/program/build: check for valid PROJECT or LIBRARY
   override PROJECT := $(filter $(VALID_PROJECTS),$(PROJECT))
   override LIBRARY := $(filter $(VALID_LIBRARIES),$(LIBRARY))
+  override PIECE := $(filter $(VALID_PIECES),$(PIECE))
 
-  ifeq (,$(PROJECT)$(LIBRARY))
+  ifeq (,$(PROJECT)$(LIBRARY)$(PIECE))
     $(error Invalid project or library. Expected PROJECT=[$(VALID_PROJECTS)] or LIBRARY=[$(VALID_LIBRARIES)])
   endif
 endif

--- a/mpxe/harness/rules.mk
+++ b/mpxe/harness/rules.mk
@@ -1,0 +1,10 @@
+# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
+# Pre-defined:
+# $(T)_SRC_ROOT: $(T)_DIR/src
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
+
+# Specify the libraries you want to include
+$(T)_DEPS := ms-common
+

--- a/mpxe/harness/src/main.c
+++ b/mpxe/harness/src/main.c
@@ -1,0 +1,41 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#include "log.h"
+
+#define MAX_LOG_LEN 1024  // Arbitrary
+#define MAX_CMD_LEN 256
+
+#define PROJ "can_communication"  // Temporarily hard coded
+
+int main(void) {
+  printf("Starting Harness\n");
+
+  bool closed = false;
+
+  char cmd[MAX_CMD_LEN];
+  snprintf(cmd, sizeof(cmd), "make build PROJECT=can_communication PLATFORM=x86; build/bin/x86/can_communication");
+  snprintf(cmd, sizeof(cmd), "make run PROJECT=%s PLATFORM=x86 ARGDEFINES=MPXE", PROJ);
+
+  FILE *proj_fp = popen(cmd, "r");
+
+  char read_buf[MAX_LOG_LEN];
+  memset(read_buf, 0, sizeof(read_buf));
+
+  // Currently, don't close until we interrupt. In future this will be ended somehow.
+  uint32_t num_lines = 0;
+  while (true) {
+    char *c = fgets(read_buf, sizeof(read_buf), proj_fp);
+    if (read_buf[strlen(read_buf) - 1] == '\n') {
+      printf("(Line %u) - %s", num_lines, read_buf);
+      num_lines++;
+      memset(read_buf, 0, sizeof(read_buf));
+    }
+  }
+
+  return 0;
+}

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -63,7 +63,7 @@ else
 endif
 
 # Platform targets
-.PHONY: run gdb
+.PHONY: run gdb mpxe
 
 run: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT) socketcan
 	@$(ENV_VARS) $<
@@ -71,9 +71,15 @@ run: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT) socketcan
 gdb: $(TARGET_BINARY) socketcan
 	@$(ENV_VARS) $(GDB) $<
 
+mpxe: $(BIN_DIR)/$(PIECE)$(PLATFORM_EXT) socketcan
+	@$(ENV_VARS) $<
+
 test_all: socketcan
 
 test: socketcan
+
+mpxe: $(BIN_DIR)/$(PIECE)$(PLATFORM_EXT) socketcan
+	@$(ENV_VARS) $<
 
 define session_wrapper
 $(ENV_VARS) $1


### PR DESCRIPTION
Adds makefile support for the command 'make mpxe'. We split MPXE into
'pieces', to avoid overalap with 'projects'. Also adds a demo hardcoded
program to run the project can_communication through mpxe, printing its
output.