### PR TITLE
[SOFT-169] Fix PCA9539R driver and smoke test

### DIFF
--- a/libraries/ms-drivers/inc/bts_7200_current_sense.h
+++ b/libraries/ms-drivers/inc/bts_7200_current_sense.h
@@ -59,6 +59,11 @@ StatusCode bts_7200_init_pca9539r(Bts7200Storage *storage, Bts7200Pca9539rSettin
 // reads them from the BTS7200 itself.
 StatusCode bts_7200_get_measurement(Bts7200Storage *storage, uint16_t *meas0, uint16_t *meas1);
 
+// quick-n-dirty hack, to do: make it good
+// Get the measurements on the callback provided. It is NOT SAFE to call this again before the
+// callback is called.
+void bts_7200_get_measurement_with_delay(Bts7200Storage *storage);
+
 // Set up a soft timer which periodically updates the storage with the latest measurements.
 // DO NOT USE if you are reading with bts_7200_get_measurement.
 StatusCode bts_7200_start(Bts7200Storage *storage);

--- a/libraries/ms-drivers/inc/bts_7200_current_sense.h
+++ b/libraries/ms-drivers/inc/bts_7200_current_sense.h
@@ -2,7 +2,7 @@
 
 // Reads current values from 2 ADC pins on the BTS 7200 switched between with a selection pin.
 // Requires GPIO, interrupts, soft timers, and ADC to be initialized in ADC_MODE_SINGLE.
-// If using with MCP23008, requires I2C to be initialized.
+// If using with PCA9539R, requires I2C to be initialized.
 
 #include "adc.h"
 #include "gpio.h"

--- a/libraries/ms-drivers/src/bts_7200_current_sense.c
+++ b/libraries/ms-drivers/src/bts_7200_current_sense.c
@@ -1,10 +1,15 @@
 #include "bts_7200_current_sense.h"
+
 #include <stddef.h>
+
+#include "delay.h"
 
 #define STM32_GPIO_STATE_SELECT_OUT_0 GPIO_STATE_LOW
 #define STM32_GPIO_STATE_SELECT_OUT_1 GPIO_STATE_HIGH
 #define PCA9539R_GPIO_STATE_SELECT_OUT_0 PCA9539R_GPIO_STATE_LOW
 #define PCA9539R_GPIO_STATE_SELECT_OUT_1 PCA9539R_GPIO_STATE_HIGH
+
+#define DSEL_CHANGE_TO_MEASURE_DELAY_US 5000
 
 static void prv_measure_current(SoftTimerId timer_id, void *context) {
   Bts7200Storage *storage = context;
@@ -87,6 +92,7 @@ StatusCode bts_7200_get_measurement(Bts7200Storage *storage, uint16_t *meas0, ui
   } else {
     pca9539r_gpio_set_state(storage->select_pin_pca9539r, PCA9539R_GPIO_STATE_SELECT_OUT_0);
   }
+  delay_us(DSEL_CHANGE_TO_MEASURE_DELAY_US);
   adc_read_raw(sense_channel, meas0);
 
   if (storage->select_pin_type == BTS7200_SELECT_PIN_STM32) {
@@ -94,6 +100,7 @@ StatusCode bts_7200_get_measurement(Bts7200Storage *storage, uint16_t *meas0, ui
   } else {
     pca9539r_gpio_set_state(storage->select_pin_pca9539r, PCA9539R_GPIO_STATE_SELECT_OUT_1);
   }
+  delay_us(DSEL_CHANGE_TO_MEASURE_DELAY_US);
   adc_read_raw(sense_channel, meas1);
 
   return STATUS_CODE_OK;

--- a/libraries/ms-drivers/src/mux.c
+++ b/libraries/ms-drivers/src/mux.c
@@ -24,10 +24,10 @@ StatusCode mux_init(MuxAddress *address) {
   };
   status_ok_or_return(gpio_init_pin(&address->mux_output_pin, &mux_output_settings));
 
-  // initialize the enable pin to high
+  // initialize the enable pin to low
   GpioSettings mux_enable_settings = {
     .direction = GPIO_DIR_OUT,
-    .state = GPIO_STATE_HIGH,
+    .state = GPIO_STATE_LOW,
     .resistor = GPIO_RES_NONE,
     .alt_function = GPIO_ALTFN_NONE,
   };

--- a/libraries/ms-drivers/src/stm32f0xx/pca9539r_gpio_expander.c
+++ b/libraries/ms-drivers/src/stm32f0xx/pca9539r_gpio_expander.c
@@ -1,6 +1,7 @@
 #include "pca9539r_gpio_expander.h"
 
 #include <stdbool.h>
+
 #include "pca9539r_gpio_expander_defs.h"
 
 // The I2C port used for all operations - won't change on each board
@@ -24,19 +25,31 @@ StatusCode pca9539r_gpio_init(const I2CPort i2c_port, const I2CAddress i2c_addre
   return STATUS_CODE_OK;
 }
 
+static void prv_read_reg(const Pca9539rGpioAddress *address, uint8_t reg0, uint8_t reg1,
+                         uint8_t *rx_data) {
+  uint8_t reg = prv_select_reg(address->pin, reg0, reg1);
+  i2c_read_reg(s_i2c_port, address->i2c_address, reg, rx_data, 1);
+}
+
+static void prv_write_reg(const Pca9539rGpioAddress *address, uint8_t reg0, uint8_t reg1,
+                          uint8_t tx_data) {
+  // PCA9539R expects the register ("command byte") as just a data byte (see figs 10, 11)
+  uint8_t reg = prv_select_reg(address->pin, reg0, reg1);
+  uint8_t data[] = { reg, tx_data };
+  i2c_write(s_i2c_port, address->i2c_address, data, SIZEOF_ARRAY(data));
+}
+
 static void prv_set_reg_bit(const Pca9539rGpioAddress *address, uint8_t reg0, uint8_t reg1,
                             bool val) {
-  uint8_t reg = prv_select_reg(address->pin, reg0, reg1);
   uint8_t bit = prv_pin_bit(address->pin);
-
   uint8_t data = 0;
-  i2c_read_reg(s_i2c_port, address->i2c_address, reg, &data, 1);
+  prv_read_reg(address, reg0, reg1, &data);
   if (val) {
     data |= 1 << bit;
   } else {
     data &= ~(1 << bit);
   }
-  i2c_write_reg(s_i2c_port, address->i2c_address, reg, &data, 1);
+  prv_write_reg(address, reg0, reg1, data);
 }
 
 StatusCode pca9539r_gpio_init_pin(const Pca9539rGpioAddress *address,
@@ -85,11 +98,9 @@ StatusCode pca9539r_gpio_toggle_state(const Pca9539rGpioAddress *address) {
 
   // optimization: instead of using set_state and get_state, we read only once
   uint8_t gpio_data = 0;
-  i2c_read_reg(s_i2c_port, address->i2c_address, prv_select_reg(address->pin, INPUT0, INPUT1),
-               &gpio_data, 1);
+  prv_read_reg(address, INPUT0, INPUT1, &gpio_data);
   gpio_data ^= 1 << prv_pin_bit(address->pin);
-  i2c_write_reg(s_i2c_port, address->i2c_address, prv_select_reg(address->pin, OUTPUT0, OUTPUT1),
-                &gpio_data, 1);
+  prv_write_reg(address, OUTPUT0, OUTPUT1, gpio_data);
 
   return STATUS_CODE_OK;
 }
@@ -105,8 +116,7 @@ StatusCode pca9539r_gpio_get_state(const Pca9539rGpioAddress *address,
   }
 
   uint8_t gpio_data = 0;
-  i2c_read_reg(s_i2c_port, address->i2c_address, prv_select_reg(address->pin, INPUT0, INPUT1),
-               &gpio_data, 1);
+  prv_read_reg(address, INPUT0, INPUT1, &gpio_data);
 
   // Read the |bit|th bit
   uint8_t bit = prv_pin_bit(address->pin);

--- a/projects/smoke_bts7200/src/main.c
+++ b/projects/smoke_bts7200/src/main.c
@@ -82,6 +82,10 @@ int main() {
     status_ok_or_return(bts_7200_init_pca9539r(&s_bts7200_storages[i], &bts_7200_settings));
   }
 
+  // enabling steering for convenience in smoke testing
+  Pca9539rGpioAddress steering_en = { .i2c_address = 0x76, .pin = PCA9539R_PIN_IO1_3 };
+  pca9539r_gpio_set_state(&steering_en, PCA9539R_GPIO_STATE_HIGH);
+
   soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_read_and_log, &s_hw_config, NULL);
   while (true) {
     wait();

--- a/projects/smoke_bts7200/src/main.c
+++ b/projects/smoke_bts7200/src/main.c
@@ -37,19 +37,27 @@ static uint8_t s_test_channels[] = { 0, 1, 2, 3, 4, 5, 6, 7 };
   { GPIO_PORT_B, 11 }
 
 static Bts7200Storage s_bts7200_storages[MAX_TEST_CHANNELS];
+static PowerDistributionCurrentHardwareConfig *s_hw_config;
 
-static void prv_read_and_log(SoftTimerId timer_id, void *context) {
-  PowerDistributionCurrentHardwareConfig *s_hw_config = context;
-  uint16_t current_0, current_1;
+static void prv_start_read(SoftTimerId, void *);
 
-  for (uint8_t i = 0; i < SIZEOF_ARRAY(s_test_channels); i++) {
-    mux_set(&s_hw_config->mux_address, s_hw_config->bts7200s[s_test_channels[i]].mux_selection);
-    bts_7200_get_measurement(&s_bts7200_storages[i], &current_0, &current_1);
-
-    LOG_DEBUG("Channel: %d; current_0: %d, current_1: %d\n", s_test_channels[i], current_0,
-              current_1);
+static void prv_log(uint16_t meas0, uint16_t meas1, void *context) {
+  uintptr_t i = (uintptr_t)context;
+  LOG_DEBUG("Channel: %d; current_0: %d, current_1: %d\n", s_test_channels[i], meas0, meas1);
+  i++;
+  if (i == SIZEOF_ARRAY(s_test_channels)) {
+    soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_start_read, (void *)0, NULL);
+  } else {
+    prv_start_read(SOFT_TIMER_INVALID_TIMER, (void *)i);
   }
-  soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_read_and_log, s_hw_config, NULL);
+}
+
+static void prv_start_read(SoftTimerId timer_id, void *context) {
+  uintptr_t i = (uintptr_t)context;
+  mux_set(&s_hw_config->mux_address, s_hw_config->bts7200s[s_test_channels[i]].mux_selection);
+  s_bts7200_storages[i].callback = prv_log;
+  s_bts7200_storages[i].callback_context = (void *)i;
+  bts_7200_get_measurement_with_delay(&s_bts7200_storages[i]);
 }
 
 int main() {
@@ -65,20 +73,19 @@ int main() {
   };
   i2c_init(I2C_PORT, &i2c_settings);
 
-  PowerDistributionCurrentHardwareConfig s_hw_config =
-      IS_FRONT_POWER_DISTRO ? FRONT_POWER_DISTRIBUTION_CURRENT_HW_CONFIG
-                            : REAR_POWER_DISTRIBUTION_CURRENT_HW_CONFIG;
+  s_hw_config = IS_FRONT_POWER_DISTRO ? &FRONT_POWER_DISTRIBUTION_CURRENT_HW_CONFIG
+                                      : &REAR_POWER_DISTRIBUTION_CURRENT_HW_CONFIG;
 
-  status_ok_or_return(mux_init(&s_hw_config.mux_address));
+  status_ok_or_return(mux_init(&s_hw_config->mux_address));
 
   // Initialize and start the BTS7200s
   Bts7200Pca9539rSettings bts_7200_settings = {
-    .sense_pin = &s_hw_config.mux_address.mux_output_pin,
-    .i2c_port = s_hw_config.i2c_port,
+    .sense_pin = &s_hw_config->mux_address.mux_output_pin,
+    .i2c_port = s_hw_config->i2c_port,
   };
 
   for (uint8_t i = 0; i < SIZEOF_ARRAY(s_test_channels); i++) {
-    bts_7200_settings.select_pin = &s_hw_config.bts7200s[s_test_channels[i]].dsel_pin;
+    bts_7200_settings.select_pin = &s_hw_config->bts7200s[s_test_channels[i]].dsel_pin;
     status_ok_or_return(bts_7200_init_pca9539r(&s_bts7200_storages[i], &bts_7200_settings));
   }
 
@@ -86,7 +93,7 @@ int main() {
   Pca9539rGpioAddress steering_en = { .i2c_address = 0x76, .pin = PCA9539R_PIN_IO1_3 };
   pca9539r_gpio_set_state(&steering_en, PCA9539R_GPIO_STATE_HIGH);
 
-  soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_read_and_log, &s_hw_config, NULL);
+  soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_start_read, (void *)0, NULL);
   while (true) {
     wait();
   }

--- a/projects/smoke_pca9539r/src/main.c
+++ b/projects/smoke_pca9539r/src/main.c
@@ -98,6 +98,7 @@ static void prv_soft_timer_callback_output(SoftTimerId timer_id, void *context) 
 }
 
 int main() {
+  gpio_init();
   interrupt_init();
   soft_timer_init();
   setup_test();

--- a/projects/smoke_spv1020/src/main.c
+++ b/projects/smoke_spv1020/src/main.c
@@ -28,7 +28,7 @@
 // modify if you want to read more or less
 #define SMOKETEST_WAIT_TIME_MS 1000
 
-#define BAUDRATE 60000
+#define BAUDRATE 6000000
 #define MOSI_PIN \
   { .port = GPIO_PORT_B, 15 }
 #define MISO_PIN \


### PR DESCRIPTION
See: https://uwmidsun.atlassian.net/wiki/spaces/ELEC/pages/1588297748/2020-09-01+PCA9539R+IO+expander+validation+notes.

During validation, I found that the PCA9539R driver mistakenly used `i2c_write_reg` instead of `i2c_write` which the PCA9539R wants. With this fix the PCA9539R driver works. Also initialized gpio in the smoke test, it wasn't previously initialized there.