### PR TITLE
Soft 299 adc channels to gpio

### DIFF
--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -20,6 +20,7 @@ typedef enum {
   NUM_ADC_CHANNELS,
 } AdcChannel;
 
+// Allows use of either channel or GpioAddress, if not using channel write null
 typedef void (*AdcCallback)(GpioAddress address, void *context);
 
 // Initialize the ADC to the desired conversion mode

--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -14,47 +14,29 @@ typedef enum {
 } AdcMode;
 
 typedef enum {
-  ADC_CHANNEL_0 = 0,
-  ADC_CHANNEL_1,
-  ADC_CHANNEL_2,
-  ADC_CHANNEL_3,
-  ADC_CHANNEL_4,
-  ADC_CHANNEL_5,
-  ADC_CHANNEL_6,
-  ADC_CHANNEL_7,
-  ADC_CHANNEL_8,
-  ADC_CHANNEL_9,
-  ADC_CHANNEL_10,
-  ADC_CHANNEL_11,
-  ADC_CHANNEL_12,
-  ADC_CHANNEL_13,
-  ADC_CHANNEL_14,
-  ADC_CHANNEL_15,
-  ADC_CHANNEL_TEMP,
+  ADC_CHANNEL_TEMP = 16,
   ADC_CHANNEL_REF,
   ADC_CHANNEL_BAT,
   NUM_ADC_CHANNELS,
 } AdcChannel;
 
-typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
+typedef void (*AdcCallback)(GpioAddress address, void *context);
 
 // Initialize the ADC to the desired conversion mode
 void adc_init(AdcMode adc_mode);
+// To access ADC_CHANNEL_TEMP, ADC_CHANNEL_REF, ADC_CHANNEL_BAT, initialize
 
 // Enable or disable a given channel.
 // A race condition may occur when setting a channel during a conversion.
 // However, it should not cause issues given the intended use cases
-StatusCode adc_set_channel(AdcChannel adc_channel, bool new_state);
-
-// Return a channel corresponding to the given GPIO address
-StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel);
+StatusCode adc_set_channel(GpioAddress address, bool new_state);
 
 // Register a callback function to be called when the specified channel
 // completes a conversion
-StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, void *context);
+StatusCode adc_register_callback(GpioAddress address, AdcCallback callback, void *context);
 
 // Obtain the raw 12-bit value read by the specified channel
-StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
+StatusCode adc_read_raw(GpioAddress address, uint16_t *reading);
 
 // Obtain the converted value at the specified channel
-StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);
+StatusCode adc_read_converted(GpioAddress address, uint16_t *reading);

--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -24,8 +24,9 @@ typedef enum {
 typedef void (*AdcCallback)(GpioAddress address, void *context);
 
 // Initialize the ADC to the desired conversion mode
+// To access/set ADC_CHANNEL_TEMP, ADC_CHANNEL_REF, ADC_CHANNEL_BAT
+// create a GpioAddress, and set pin to requisite AdcChannel
 void adc_init(AdcMode adc_mode);
-// To access ADC_CHANNEL_TEMP, ADC_CHANNEL_REF, ADC_CHANNEL_BAT, initialize
 
 // Enable or disable a given channel.
 // A race condition may occur when setting a channel during a conversion.

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -16,7 +16,7 @@
 static volatile uint8_t s_callback_runs = 0;
 static volatile bool s_callback_ran = false;
 
-static GpioAddress s_address[] = {
+static const GpioAddress s_address[] = {
   {
       GPIO_PORT_A,
       0,
@@ -70,7 +70,6 @@ void setup_test() {
     GPIO_RES_NONE,      //
     GPIO_ALTFN_ANALOG,  //
   };
-
   gpio_init();
   interrupt_init();
 
@@ -99,10 +98,8 @@ void test_set_callback(void) {
   // arguments
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS,
                     adc_register_callback(s_address[3], prv_callback, NULL));
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_register_callback(s_address[4], prv_callback, NULL));
 
-  for (uint8_t i = 0; i < 2; i++) {
-    TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_register_callback(s_address[i], prv_callback, NULL));
-  }
   for (uint8_t i = 0; i < 2; i++) {
     adc_set_channel(s_address[i], true);
   }


### PR DESCRIPTION
Converted all functions in adc.c to use gpio pins instead of channels. Also rewrote x86 implementation and test_adc.c to deal with new changes. When tests are run on x86 all pass. Not to sure which programs use adc.h, but if codebase will need to be reworked to deal with this change, let me know and I can create a ticket, and add it to this pull request. Thanks!

**Overview of changes**
STM32F0xx:
- Changed all function stubs to use GpioAddresses instead of channels
- Reduced AdcChannel enum to only channels which do not have a corresponding pin
- Made adc_get_channel() private, and it is now used in all other functions at the very beginning to convert from gpio to channels (same logic in each function is preserved)
- Added prv_channel_to_gpio() -> this function is only used in ADC1_COMP_IRQHandler(), as channels are gotten directly from the system and need to be passed as gpioAddresses to the callback. If anyone has a better idea pls let me know

x86:
- Made similar changes to those above

Test_adc:
- Created static Gpio Array, and switched tests to gpioaddresses
- switched repetitive tests used on pins 1, 2, and 3 to for loops