### PR TITLE
[SOFT-311] Don't turn on horn in startup sequence

### DIFF
--- a/projects/power_distribution/src/pd_gpio_config.c
+++ b/projects/power_distribution/src/pd_gpio_config.c
@@ -118,7 +118,7 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
               .event_id = POWER_DISTRIBUTION_POWER_SEQUENCE_EVENT_TURN_ON_EVERYTHING_MAIN,
               .outputs =
                   (PowerDistributionGpioOutputSpec[]){
-                      // Turn on: driver display, steering, centre console, pedal, horn, speaker,
+                      // Turn on: driver display, steering, centre console, pedal, speaker,
                       // left display, right display, rear display, left camera, right camera, main
                       // rPi, rear rPi
                       {
@@ -138,10 +138,6 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                       {
-                          .address = FRONT_PIN_HORN_EN,
-                          .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
-                      },
-                      {
                           .address = FRONT_PIN_SPEAKER_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
@@ -174,13 +170,13 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                   },
-              .num_outputs = 13,
+              .num_outputs = 12,
           },
           {
               .event_id = POWER_DISTRIBUTION_POWER_SEQUENCE_EVENT_TURN_ON_EVERYTHING_AUX,
               .outputs =
                   (PowerDistributionGpioOutputSpec[]){
-                      // Turn on: driver display, steering, centre console, pedal, horn, speaker,
+                      // Turn on: driver display, steering, centre console, pedal, speaker,
                       // left display, right display, rear display, main rPi, rear rPi
                       // Turn off: left camera, right camera (in case we go from on to aux)
                       {
@@ -200,10 +196,6 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                       {
-                          .address = FRONT_PIN_HORN_EN,
-                          .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
-                      },
-                      {
                           .address = FRONT_PIN_SPEAKER_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
@@ -236,13 +228,13 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
                       },
                   },
-              .num_outputs = 13,
+              .num_outputs = 12,
           },
           {
               .event_id = POWER_DISTRIBUTION_POWER_SEQUENCE_EVENT_TURN_OFF_EVERYTHING,
               .outputs =
                   (PowerDistributionGpioOutputSpec[]){
-                      // Turn on (or keep on): centre console, pedal, horn
+                      // Turn on (or keep on): centre console, pedal
                       // Turn off: driver display, steering, speaker, left display, right display,
                       // rear display, main rPi, rear rPi, left camera, right camera, parking brake,
                       // daytime running lights, front left turn light, front right turn light
@@ -252,10 +244,6 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                       },
                       {
                           .address = FRONT_PIN_PEDAL_EN,
-                          .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
-                      },
-                      {
-                          .address = FRONT_PIN_HORN_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                       {
@@ -315,7 +303,7 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
                       },
                   },
-              .num_outputs = 17,
+              .num_outputs = 16,
           },
       },
   .num_events = 12,

--- a/projects/power_distribution/src/pd_gpio_config.c
+++ b/projects/power_distribution/src/pd_gpio_config.c
@@ -119,8 +119,8 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
               .outputs =
                   (PowerDistributionGpioOutputSpec[]){
                       // Turn on: driver display, steering, centre console, pedal, speaker,
-                      // left display, right display, rear display, left camera, right camera, main
-                      // rPi, rear rPi
+                      // left display, right display, main display, rear display, left camera, right
+                      // camera, main rPi, rear rPi
                       {
                           .address = FRONT_PIN_DVR_DISP_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
@@ -150,6 +150,10 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                       {
+                          .address = FRONT_PIN_MAIN_DISP_EN,
+                          .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
+                      },
+                      {
                           .address = FRONT_PIN_REAR_DISP_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
@@ -170,14 +174,14 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                   },
-              .num_outputs = 12,
+              .num_outputs = 13,
           },
           {
               .event_id = POWER_DISTRIBUTION_POWER_SEQUENCE_EVENT_TURN_ON_EVERYTHING_AUX,
               .outputs =
                   (PowerDistributionGpioOutputSpec[]){
                       // Turn on: driver display, steering, centre console, pedal, speaker,
-                      // left display, right display, rear display, main rPi, rear rPi
+                      // left display, right display, main display, rear display, main rPi, rear rPi
                       // Turn off: left camera, right camera (in case we go from on to aux)
                       {
                           .address = FRONT_PIN_DVR_DISP_EN,
@@ -208,6 +212,10 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
                       {
+                          .address = FRONT_PIN_MAIN_DISP_EN,
+                          .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
+                      },
+                      {
                           .address = FRONT_PIN_REAR_DISP_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
                       },
@@ -228,7 +236,7 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
                       },
                   },
-              .num_outputs = 12,
+              .num_outputs = 13,
           },
           {
               .event_id = POWER_DISTRIBUTION_POWER_SEQUENCE_EVENT_TURN_OFF_EVERYTHING,
@@ -236,8 +244,9 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                   (PowerDistributionGpioOutputSpec[]){
                       // Turn on (or keep on): centre console, pedal
                       // Turn off: driver display, steering, speaker, left display, right display,
-                      // rear display, main rPi, rear rPi, left camera, right camera, parking brake,
-                      // daytime running lights, front left turn light, front right turn light
+                      // main display rear display, main rPi, rear rPi, left camera, right camera,
+                      // parking brake, daytime running lights, front left turn light, front right
+                      // turn light
                       {
                           .address = FRONT_PIN_CTR_CONSL_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_HIGH,
@@ -264,6 +273,10 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                       },
                       {
                           .address = FRONT_PIN_RIGHT_DISPLAY_EN,
+                          .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
+                      },
+                      {
+                          .address = FRONT_PIN_MAIN_DISP_EN,
                           .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
                       },
                       {
@@ -303,7 +316,7 @@ const PowerDistributionGpioConfig FRONT_POWER_DISTRIBUTION_GPIO_CONFIG = {
                           .state = POWER_DISTRIBUTION_GPIO_STATE_LOW,
                       },
                   },
-              .num_outputs = 16,
+              .num_outputs = 17,
           },
       },
   .num_events = 12,


### PR DESCRIPTION
So... power distribution was turning on the horn in the main power up / aux power up / power off sequences. Why? Who knows. In any case, it no longer does that. Instead, the main display is turned on (on in main/aux, off at power off), which was likely omitted as an oversight.