### PR TITLE
[SOFT-299] Add Gpio abstraction to adc library

### DIFF
--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -7,6 +7,12 @@
 #include "gpio.h"
 #include "status.h"
 
+//Following definitions allow ADC internal channels to be accessed
+//via compound literal GpioAddresses -> can be passed to new functions
+#define ADC_CHANNEL_TEMP_PIN ((GpioAddress){0,16})
+#define ADC_CHANNEL_REF_PIN ((GpioAddress){0,17})
+#define ADC_CHANNEL_BAT_PIN ((GpioAddress){0,18})
+
 typedef enum {
   ADC_MODE_SINGLE = 0,
   ADC_MODE_CONTINUOUS,
@@ -36,14 +42,33 @@ typedef enum {
   NUM_ADC_CHANNELS,
 } AdcChannel;
 
-typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
-
+typedef void (*AdcPinCallback)(GpioAddress address, void *context);
 // Initialize the ADC to the desired conversion mode
 void adc_init(AdcMode adc_mode);
 
-// Enable or disable a given channel.
-// A race condition may occur when setting a channel during a conversion.
+// Enable or disable a given pin.
+// A race condition may occur when setting a pin during a conversion.
 // However, it should not cause issues given the intended use cases
+StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
+
+// Register a callback function to be called when the specified pin
+// completes a conversion
+StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
+
+// Obtain the raw 12-bit value read by the specified pin
+StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
+
+// Obtain the converted value at the specified pin
+StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
+
+
+
+
+//Following functions use adc channels as seen above
+//but are now deprecated, they are still used in the current code base
+
+typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
+
 StatusCode adc_set_channel(AdcChannel adc_channel, bool new_state);
 
 // Return a channel corresponding to the given GPIO address
@@ -58,3 +83,5 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
 
 // Obtain the converted value at the specified channel
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);
+
+//Begin 

--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -8,7 +8,7 @@
 #include "status.h"
 
 // Following definitions allow ADC internal channels to be accessed
-// via compound literal GpioAddresses -> can be passed to new functions
+// via compound literal GpioAddresses -> can be passed to pin functions
 #define ADC_CHANNEL_TEMP_PIN ((GpioAddress){ 0, 16 })
 #define ADC_CHANNEL_REF_PIN ((GpioAddress){ 0, 17 })
 #define ADC_CHANNEL_BAT_PIN ((GpioAddress){ 0, 18 })
@@ -19,6 +19,28 @@ typedef enum {
   NUM_ADC_MODES,
 } AdcMode;
 
+typedef void (*AdcPinCallback)(GpioAddress address, void *context);
+
+// Initialize the ADC to the desired conversion mode
+void adc_init(AdcMode adc_mode);
+
+// Enable or disable a given pin.
+// A race condition may occur when setting a pin during a conversion.
+// However, it should not cause issues given the intended use cases
+StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
+
+// Register a callback function to be called when the specified pin
+// completes a conversion
+StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
+
+// Obtain the raw 12-bit value read by the specified pin
+StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
+
+// Obtain the converted value at the specified pin
+StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
+
+// Following code and functions use adc channels as seen below
+// but are now deprecated; they are still used in the current code base
 typedef enum {
   ADC_CHANNEL_0 = 0,
   ADC_CHANNEL_1,
@@ -42,30 +64,11 @@ typedef enum {
   NUM_ADC_CHANNELS,
 } AdcChannel;
 
-typedef void (*AdcPinCallback)(GpioAddress address, void *context);
-// Initialize the ADC to the desired conversion mode
-void adc_init(AdcMode adc_mode);
-
-// Enable or disable a given pin.
-// A race condition may occur when setting a pin during a conversion.
-// However, it should not cause issues given the intended use cases
-StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
-
-// Register a callback function to be called when the specified pin
-// completes a conversion
-StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
-
-// Obtain the raw 12-bit value read by the specified pin
-StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
-
-// Obtain the converted value at the specified pin
-StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
-
-// Following functions use adc channels as seen above
-// but are now deprecated, they are still used in the current code base
-
 typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
 
+// Enable or disable a given channel.
+// A race condition may occur when setting a channel during a conversion.
+// However, it should not cause issues given the intended use cases
 StatusCode adc_set_channel(AdcChannel adc_channel, bool new_state);
 
 // Return a channel corresponding to the given GPIO address
@@ -80,5 +83,3 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
 
 // Obtain the converted value at the specified channel
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);
-
-// Begin

--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -7,12 +7,6 @@
 #include "gpio.h"
 #include "status.h"
 
-// Following definitions allow ADC internal channels to be accessed
-// via compound literal GpioAddresses -> can be passed to pin functions
-#define ADC_CHANNEL_TEMP_PIN ((GpioAddress){ 0, 16 })
-#define ADC_CHANNEL_REF_PIN ((GpioAddress){ 0, 17 })
-#define ADC_CHANNEL_BAT_PIN ((GpioAddress){ 0, 18 })
-
 typedef enum {
   ADC_MODE_SINGLE = 0,
   ADC_MODE_CONTINUOUS,
@@ -21,26 +15,7 @@ typedef enum {
 
 typedef void (*AdcPinCallback)(GpioAddress address, void *context);
 
-// Initialize the ADC to the desired conversion mode
-void adc_init(AdcMode adc_mode);
-
-// Enable or disable a given pin.
-// A race condition may occur when setting a pin during a conversion.
-// However, it should not cause issues given the intended use cases
-StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
-
-// Register a callback function to be called when the specified pin
-// completes a conversion
-StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
-
-// Obtain the raw 12-bit value read by the specified pin
-StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
-
-// Obtain the converted value at the specified pin
-StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
-
-// Following code and functions use adc channels as seen below
-// but are now deprecated; they are still used in the current code base
+// Following enum deprecated in favour of GpioAddress Version
 typedef enum {
   ADC_CHANNEL_0 = 0,
   ADC_CHANNEL_1,
@@ -64,22 +39,49 @@ typedef enum {
   NUM_ADC_CHANNELS,
 } AdcChannel;
 
+// Following typedef deprecated in favour of GpioAddress Version
 typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
 
-// Enable or disable a given channel.
+// Initialize the ADC to the desired conversion mode
+void adc_init(AdcMode adc_mode);
+
+// Enable or disable a given pin.
+// A race condition may occur when setting a pin during a conversion.
+// However, it should not cause issues given the intended use cases
+// To set adc channels REF/TEMP/BAT, you must use adc_set_channel() below
+StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
+
+// Register a callback function to be called when the specified pin
+// completes a conversion
+StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
+
+// Obtain the raw 12-bit value read by the specified pin
+StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
+
+// Obtain the converted value at the specified pin
+StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
+
+// Following code and functions use adc channels as seen below
+// but are now deprecated; they are still used in the current code base
+
+// Enable or disable a given channel - must be used for channels TEMP/REF/BAT
 // A race condition may occur when setting a channel during a conversion.
 // However, it should not cause issues given the intended use cases
 StatusCode adc_set_channel(AdcChannel adc_channel, bool new_state);
 
+// Deprecated in favour of GpioAddress version
 // Return a channel corresponding to the given GPIO address
 StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel);
 
+// Deprecated in favour of GpioAddress version
 // Register a callback function to be called when the specified channel
 // completes a conversion
 StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, void *context);
 
+// Deprecated in favour of GpioAddress version
 // Obtain the raw 12-bit value read by the specified channel
 StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
 
+// Deprecated in favour of GpioAddress version
 // Obtain the converted value at the specified channel
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);

--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -7,11 +7,11 @@
 #include "gpio.h"
 #include "status.h"
 
-//Following definitions allow ADC internal channels to be accessed
-//via compound literal GpioAddresses -> can be passed to new functions
-#define ADC_CHANNEL_TEMP_PIN ((GpioAddress){0,16})
-#define ADC_CHANNEL_REF_PIN ((GpioAddress){0,17})
-#define ADC_CHANNEL_BAT_PIN ((GpioAddress){0,18})
+// Following definitions allow ADC internal channels to be accessed
+// via compound literal GpioAddresses -> can be passed to new functions
+#define ADC_CHANNEL_TEMP_PIN ((GpioAddress){ 0, 16 })
+#define ADC_CHANNEL_REF_PIN ((GpioAddress){ 0, 17 })
+#define ADC_CHANNEL_BAT_PIN ((GpioAddress){ 0, 18 })
 
 typedef enum {
   ADC_MODE_SINGLE = 0,
@@ -61,11 +61,8 @@ StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
 // Obtain the converted value at the specified pin
 StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
 
-
-
-
-//Following functions use adc channels as seen above
-//but are now deprecated, they are still used in the current code base
+// Following functions use adc channels as seen above
+// but are now deprecated, they are still used in the current code base
 
 typedef void (*AdcCallback)(AdcChannel adc_channel, void *context);
 
@@ -84,4 +81,4 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
 // Obtain the converted value at the specified channel
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);
 
-//Begin 
+// Begin

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -134,9 +134,7 @@ void adc_init(AdcMode adc_mode) {
   }
 
   for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
-    s_adc_interrupts[i].callback = NULL;
-    s_adc_interrupts[i].pin_callback = NULL;
-    s_adc_interrupts[i].context = NULL;
+    prv_reset_channel(i);
   }
 
   // Configure internal reference channel to run by default for voltage

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -55,7 +55,7 @@ static uint16_t prv_get_vdda(uint16_t reading) {
   return reading;
 }
 
-static void prv_check_channel_valid_and_enabled(AdcChannel channel) {
+static void prv_reset_channel(AdcChannel channel) {
   s_adc_interrupts[channel].callback = NULL;
   s_adc_interrupts[channel].pin_callback = NULL;
   s_adc_interrupts[channel].context = NULL;
@@ -78,7 +78,7 @@ static GpioAddress prv_channel_to_gpio(uint8_t adc_channel) {
   return address;
 }
 
-static StatusCode prv_channel_check(AdcChannel adc_channel) {
+static StatusCode prv_check_channel_valid_and_enabled(AdcChannel adc_channel) {
   if (adc_channel >= NUM_ADC_CHANNELS) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -134,7 +134,7 @@ void adc_init(AdcMode adc_mode) {
   }
 
   for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
-    prv_check_channel_valid_and_enabled(i);
+    prv_reset_channel(i);
   }
 
   // Configure internal reference channel to run by default for voltage
@@ -206,15 +206,15 @@ StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel) {
 }
 
 StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, void *context) {
-  status_ok_or_return(prv_channel_check(adc_channel));
-  prv_check_channel_valid_and_enabled(adc_channel);
+  status_ok_or_return(prv_check_channel_valid_and_enabled(adc_channel));
+  prv_reset_channel(adc_channel);
   s_adc_interrupts[adc_channel].callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;
 }
 
 StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading) {
-  status_ok_or_return(prv_channel_check(adc_channel));
+  status_ok_or_return(prv_check_channel_valid_and_enabled(adc_channel));
   if (!s_adc_status.continuous) {
     ADC_StartOfConversion(ADC1);
     while (ADC_GetFlagStatus(ADC1, ADC_FLAG_EOSEQ)) {
@@ -227,7 +227,7 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading) {
 }
 
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading) {
-  status_ok_or_return(prv_channel_check(adc_channel));
+  status_ok_or_return(prv_check_channel_valid_and_enabled(adc_channel));
   uint16_t adc_reading = 0;
   adc_read_raw(adc_channel, &adc_reading);
 
@@ -289,8 +289,8 @@ StatusCode adc_set_channel_pin(GpioAddress address, bool new_state) {
 StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context) {
   AdcChannel adc_channel;
   status_ok_or_return(adc_get_channel(address, &adc_channel));
-  status_ok_or_return(prv_channel_check(adc_channel));
-  prv_check_channel_valid_and_enabled(adc_channel);
+  status_ok_or_return(prv_check_channel_valid_and_enabled(adc_channel));
+  prv_reset_channel(adc_channel);
   s_adc_interrupts[adc_channel].pin_callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -127,6 +127,8 @@ void adc_init(AdcMode adc_mode) {
   for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
     s_adc_interrupts[i].callback = NULL;
     s_adc_interrupts[i].context = NULL;
+    s_adc_pin_interrupts[i].callback = NULL;
+    s_adc_pin_interrupts[i].context = NULL;
   }
 
   // Configure internal reference channel to run by default for voltage

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -55,7 +55,7 @@ static uint16_t prv_get_vdda(uint16_t reading) {
   return reading;
 }
 
-static void prv_reset_channel(AdcChannel channel) {
+static void prv_check_channel_valid_and_enabled(AdcChannel channel) {
   s_adc_interrupts[channel].callback = NULL;
   s_adc_interrupts[channel].pin_callback = NULL;
   s_adc_interrupts[channel].context = NULL;
@@ -134,7 +134,7 @@ void adc_init(AdcMode adc_mode) {
   }
 
   for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
-    prv_reset_channel(i);
+    prv_check_channel_valid_and_enabled(i);
   }
 
   // Configure internal reference channel to run by default for voltage
@@ -207,7 +207,7 @@ StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel) {
 
 StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, void *context) {
   status_ok_or_return(prv_channel_check(adc_channel));
-  prv_reset_channel(adc_channel);
+  prv_check_channel_valid_and_enabled(adc_channel);
   s_adc_interrupts[adc_channel].callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;
@@ -290,7 +290,7 @@ StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callbac
   AdcChannel adc_channel;
   status_ok_or_return(adc_get_channel(address, &adc_channel));
   status_ok_or_return(prv_channel_check(adc_channel));
-  prv_reset_channel(adc_channel);
+  prv_check_channel_valid_and_enabled(adc_channel);
   s_adc_interrupts[adc_channel].pin_callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -15,18 +15,6 @@
 // datasheet
 #define ADC_VREFINT_CAL 0x1FFFF7ba
 
-typedef struct AdcInterrupt {
-  AdcCallback callback;
-  void *context;
-  uint16_t reading;
-} AdcInterrupt;
-
-typedef struct AdcPinInterrupt {
-  AdcPinCallback callback;
-  void *context;
-  uint16_t reading;
-} AdcPinInterrupt;
-
 typedef struct AdcStatus {
   uint32_t sequence;
   bool continuous;
@@ -39,10 +27,26 @@ typedef enum {
   NUM_ADC_INP,
 } AdcInputs;
 
-static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
-static AdcPinInterrupt s_adc_pin_interrupts[NUM_ADC_CHANNELS];
 static AdcInputs s_adc_inputs[NUM_ADC_CHANNELS];
 static AdcStatus s_adc_status;
+
+// Functionalities used by GpioAddress version of adc library
+typedef struct AdcInterrupt {
+  AdcCallback callback;
+  void *context;
+  uint16_t reading;
+} AdcInterrupt;
+
+static AdcPinInterrupt s_adc_pin_interrupts[NUM_ADC_CHANNELS];
+
+// Functionalities used by AdcChannel version of adc library
+typedef struct AdcPinInterrupt {
+  AdcPinCallback callback;
+  void *context;
+  uint16_t reading;
+} AdcPinInterrupt;
+
+static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
 
 // Formula obtained from section 13.9 of the reference manual. Returns reading
 // in kelvin

--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -29,7 +29,7 @@ typedef struct AdcInterrupt {
   uint16_t reading;
 } AdcInterrupt;
 
-static AdcPinInterrupt s_adc_pin_interrupts[NUM_ADC_CHANNELS];
+static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
 
 // Functionalities used by AdcChannel version of adc library
 typedef struct AdcPinInterrupt {
@@ -38,7 +38,7 @@ typedef struct AdcPinInterrupt {
   uint16_t reading;
 } AdcPinInterrupt;
 
-static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
+static AdcPinInterrupt s_adc_pin_interrupts[NUM_ADC_CHANNELS];
 
 // Formula obtained from section 13.9 of the reference manual. Returns reading
 // in kelvin
@@ -284,15 +284,15 @@ void ADC1_COMP_IRQHandler() {
         s_adc_pin_interrupts[current_channel].callback(
             prv_channel_to_gpio(current_channel), s_adc_pin_interrupts[current_channel].context);
       }
+      s_adc_interrupts[current_channel].reading = reading;
+      s_adc_status.sequence &= ~((uint32_t)1 << current_channel);
     }
-    s_adc_interrupts[current_channel].reading = reading;
-    s_adc_status.sequence &= ~((uint32_t)1 << current_channel);
   }
-}
-if (ADC_GetITStatus(ADC1, ADC_IT_EOSEQ)) {
-  s_adc_status.sequence = ADC1->CHSELR;
-  ADC_ClearITPendingBit(ADC1, ADC_IT_EOSEQ);
-}
+
+  if (ADC_GetITStatus(ADC1, ADC_IT_EOSEQ)) {
+    s_adc_status.sequence = ADC1->CHSELR;
+    ADC_ClearITPendingBit(ADC1, ADC_IT_EOSEQ);
+  }
 }
 
 // Begin implementation of GpioAddress function definitions

--- a/libraries/ms-common/src/x86/adc.c
+++ b/libraries/ms-common/src/x86/adc.c
@@ -123,7 +123,7 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading) {
   if (adc_channel >= NUM_ADC_CHANNELS) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
-  if (s_active_channels[adc_channel]) {
+  if (!s_active_channels[adc_channel]) {
     return status_code(STATUS_CODE_EMPTY);
   }
 

--- a/libraries/ms-common/src/x86/adc.c
+++ b/libraries/ms-common/src/x86/adc.c
@@ -20,8 +20,22 @@ typedef struct AdcInterrupt {
   uint16_t reading;
 } AdcInterrupt;
 
-static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
+typedef enum {
+  ADC_NONE,
+  ADC_CHANNEL,
+  ADC_GPIO,
+  NUM_ADC_INP,
+} AdcInputs;
 
+typedef struct AdcPinInterrupt {
+  AdcPinCallback callback;
+  void *context;
+  uint16_t reading;
+} AdcPinInterrupt;
+
+static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
+static AdcPinInterrupt s_adc_pin_interrupts[NUM_ADC_CHANNELS];
+static AdcInputs s_adc_inputs[NUM_ADC_CHANNELS];
 static bool s_active_channels[NUM_ADC_CHANNELS];
 
 static uint16_t prv_get_temp(uint16_t reading) {
@@ -61,28 +75,28 @@ StatusCode adc_set_channel(AdcChannel adc_channel, bool new_state) {
 
 StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel) {
   *adc_channel = address.pin;
-
-  switch (address.port) {
-    case GPIO_PORT_A:
-      if (address.pin > 7) {
-        return status_code(STATUS_CODE_INVALID_ARGS);
-      }
-      break;
-    case GPIO_PORT_B:
-      if (address.pin > 1) {
-        return status_code(STATUS_CODE_INVALID_ARGS);
-      }
-      *adc_channel += 8;
-      break;
-    case GPIO_PORT_C:
-      if (address.pin > 5) {
-        return status_code(STATUS_CODE_INVALID_ARGS);
-      }
-      *adc_channel += 10;
-      break;
+  if (address.pin < 16) {
+    switch (address.port) {
+      case GPIO_PORT_A:
+        if (address.pin > 7) {
+          return status_code(STATUS_CODE_INVALID_ARGS);
+        }
+        break;
+      case GPIO_PORT_B:
+        if (address.pin > 1) {
+          return status_code(STATUS_CODE_INVALID_ARGS);
+        }
+        *adc_channel += 8;
+        break;
+      case GPIO_PORT_C:
+        if (address.pin > 5) {
+          return status_code(STATUS_CODE_INVALID_ARGS);
+        }
+        *adc_channel += 10;
+        break;
+    }
   }
-
-  if (*adc_channel > ADC_CHANNEL_15) {
+  if (*adc_channel >= NUM_ADC_CHANNELS) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
   return STATUS_CODE_OK;
@@ -98,6 +112,7 @@ StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, v
 
   s_adc_interrupts[adc_channel].callback = callback;
   s_adc_interrupts[adc_channel].context = context;
+  s_adc_inputs[adc_channel] = ADC_CHANNEL;
 
   return STATUS_CODE_OK;
 }
@@ -153,4 +168,40 @@ StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading) {
   *reading = (adc_reading * vdda) / 4095;
 
   return STATUS_CODE_OK;
+}
+
+// Begin implementation of GpioAddress function definitions
+StatusCode adc_set_channel_pin(GpioAddress address, bool new_state) {
+  AdcChannel channel;
+  status_ok_or_return(adc_get_channel(address, &channel));
+  return adc_set_channel(channel, new_state);
+}
+
+StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context) {
+  AdcChannel adc_channel;
+  status_ok_or_return(adc_get_channel(address, &adc_channel));
+  if (adc_channel >= NUM_ADC_CHANNELS) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  if (s_active_channels[adc_channel] != true) {
+    return status_code(STATUS_CODE_EMPTY);
+  }
+
+  s_adc_pin_interrupts[adc_channel].callback = callback;
+  s_adc_pin_interrupts[adc_channel].context = context;
+  s_adc_inputs[adc_channel] = ADC_GPIO;
+
+  return STATUS_CODE_OK;
+}
+
+StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading) {
+  AdcChannel channel;
+  status_ok_or_return(adc_get_channel(address, &channel));
+  return adc_read_raw(channel, reading);
+}
+
+StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading) {
+  AdcChannel channel;
+  status_ok_or_return(adc_get_channel(address, &channel));
+  return adc_read_converted(channel, reading);
 }

--- a/libraries/ms-common/src/x86/adc.c
+++ b/libraries/ms-common/src/x86/adc.c
@@ -34,7 +34,7 @@ static uint16_t prv_get_vdda(uint16_t reading) {
   return ADC_VDDA_RETURN;
 }
 
-static void prv_reset_channel(AdcChannel channel) {
+static void prv_check_channel_valid_and_enabled(AdcChannel channel) {
   s_adc_interrupts[channel].callback = NULL;
   s_adc_interrupts[channel].pin_callback = NULL;
   s_adc_interrupts[channel].context = NULL;
@@ -84,7 +84,7 @@ void adc_init(AdcMode adc_mode) {
     soft_timer_start_millis(ADC_CONTINUOUS_CB_FREQ_MS, prv_periodic_continous_cb, NULL, NULL);
   }
   for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
-    prv_reset_channel(i);
+    prv_check_channel_valid_and_enabled(i);
   }
   adc_set_channel(ADC_CHANNEL_REF, true);
 }
@@ -126,7 +126,7 @@ StatusCode adc_get_channel(GpioAddress address, AdcChannel *adc_channel) {
 
 StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, void *context) {
   status_ok_or_return(prv_channel_check(adc_channel));
-  prv_reset_channel(adc_channel);
+  prv_check_channel_valid_and_enabled(adc_channel);
   s_adc_interrupts[adc_channel].callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;
@@ -188,7 +188,7 @@ StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callbac
   AdcChannel adc_channel;
   status_ok_or_return(adc_get_channel(address, &adc_channel));
   status_ok_or_return(prv_channel_check(adc_channel));
-  prv_reset_channel(adc_channel);
+  prv_check_channel_valid_and_enabled(adc_channel);
   s_adc_interrupts[adc_channel].pin_callback = callback;
   s_adc_interrupts[adc_channel].context = context;
   return STATUS_CODE_OK;

--- a/libraries/ms-common/src/x86/adc.c
+++ b/libraries/ms-common/src/x86/adc.c
@@ -83,7 +83,9 @@ void adc_init(AdcMode adc_mode) {
   if (adc_mode == ADC_MODE_CONTINUOUS) {
     soft_timer_start_millis(ADC_CONTINUOUS_CB_FREQ_MS, prv_periodic_continous_cb, NULL, NULL);
   }
-
+  for (size_t i = 0; i < NUM_ADC_CHANNELS; ++i) {
+    prv_reset_channel(i);
+  }
   adc_set_channel(ADC_CHANNEL_REF, true);
 }
 

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -155,11 +155,10 @@ void test_single(void) {
   TEST_ASSERT_TRUE(s_callback_ran);
   TEST_ASSERT_TRUE(s_callback_runs > 0);
   TEST_ASSERT_TRUE(reading < 4095);
+  TEST_ASSERT_FALSE(s_pin_callback_ran);
 }
 
 void test_continuous() {
-  s_callback_runs = 0;
-  s_callback_ran = false;
 
   // Initialize ADC and check that adc_init() can properly reset the ADC
   adc_init(ADC_MODE_CONTINUOUS);
@@ -270,9 +269,6 @@ void test_pin_set_callback(void) {
 }
 
 void test_pin_single(void) {
-  // ensure no more AdcCallbacks called, only AdcPinCallbacks
-  s_callback_ran = false;
-
   uint16_t reading;
   // Initialize the ADC to single mode and configure the channels
   adc_init(ADC_MODE_SINGLE);
@@ -308,8 +304,6 @@ void test_pin_single(void) {
 }
 
 void test_pin_continuous() {
-  s_callback_runs = 0;
-  s_callback_ran = false;
   // Initialize ADC and check that adc_init() can properly reset the ADC
   adc_init(ADC_MODE_CONTINUOUS);
 
@@ -349,4 +343,20 @@ void test_pin_read_continuous(void) {
   adc_register_callback_pin(s_address[0], prv_callback_pin, NULL);
 
   prv_adc_check_range_pin(s_address[0]);
+}
+
+// test to help with other tests
+void test_adc_mock_reading() {
+  adc_init(ADC_MODE_SINGLE);
+  GpioAddress address = { .port = GPIO_PORT_A, .pin = 0 };
+  AdcChannel channel;
+  adc_get_channel(address, &channel);
+  adc_set_channel(channel, true);
+
+  uint16_t reading;
+
+  adc_register_callback(channel, prv_mock_read_callback, &reading);
+
+  adc_read_raw(channel, &reading);
+  TEST_ASSERT_TRUE(reading == ADC_MOCK_READING);
 }

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -159,7 +159,6 @@ void test_single(void) {
 }
 
 void test_continuous() {
-
   // Initialize ADC and check that adc_init() can properly reset the ADC
   adc_init(ADC_MODE_CONTINUOUS);
 

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -353,11 +353,11 @@ void test_pin_continuous() {
   }
 
   // Run a busy loop until a callback is triggered
-  while (!s_callback_runs) {
+  while (!s_pin_callback_ran) {
   }
 
-  TEST_ASSERT_TRUE(s_callback_ran);
-  TEST_ASSERT_TRUE(s_callback_runs > 0);
+  TEST_ASSERT_TRUE(s_pin_callback_ran);
+  TEST_ASSERT_TRUE(s_pin_callback_runs > 0);
 }
 
 void test_pin_read_single(void) {

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -11,20 +11,20 @@
 
 #define ADC_MOCK_READING 999
 
-static volatile uint8_t s_callback_runs = 0;
-static volatile bool s_callback_ran = false;
+static volatile uint8_t s_callback_runs;
+static volatile bool s_callback_ran;
 
-static volatile uint8_t s_pin_callback_runs = 0;
-static volatile bool s_pin_callback_ran = false;
+static volatile uint8_t s_pin_callback_runs;
+static volatile bool s_pin_callback_ran;
 
 static const GpioAddress s_address[] = {
   { GPIO_PORT_A, 0 },
   { GPIO_PORT_A, 1 },
   { GPIO_PORT_A, 2 },
-  { GPIO_PORT_A, 3 },
 };
 
 static const GpioAddress s_invalid_pin = { NUM_GPIO_PORTS, NUM_ADC_CHANNELS };
+static const GpioAddress s_empty_pin = { GPIO_PORT_A, 3 };
 
 void prv_callback(AdcChannel adc_channel, void *context) {
   s_callback_runs++;
@@ -248,11 +248,11 @@ void test_pin_set_channel(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, adc_set_channel_pin(s_invalid_pin, true));
 
   for (uint8_t i = 0; i < SIZEOF_ARRAY(s_address); i++) {
-    TEST_ASSERT_EQUAL(STATUS_CODE_OK, adc_set_channel_pin(s_address[i], true));
+    TEST_ASSERT_EQUAL(STATUS_CODE_OK, adc_set_channel_pin(s_address[i], false));
   }
 
   for (uint8_t i = 0; i < SIZEOF_ARRAY(s_address); i++) {
-    TEST_ASSERT_EQUAL(STATUS_CODE_OK, adc_set_channel_pin(s_address[i], false));
+    TEST_ASSERT_EQUAL(STATUS_CODE_OK, adc_set_channel_pin(s_address[i], true));
   }
 }
 
@@ -261,7 +261,7 @@ void test_pin_set_callback(void) {
                     adc_register_callback_pin(s_invalid_pin, prv_callback_pin, NULL));
 
   TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY,
-                    adc_register_callback_pin(s_address[3], prv_callback_pin, NULL));
+                    adc_register_callback_pin(s_empty_pin, prv_callback_pin, NULL));
 
   for (uint8_t i = 0; i < SIZEOF_ARRAY(s_address); i++) {
     TEST_ASSERT_EQUAL(STATUS_CODE_OK,
@@ -295,7 +295,7 @@ void test_pin_single(void) {
   }
 
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, adc_read_raw_pin(s_invalid_pin, &reading));
-  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_read_raw_pin(s_address[3], &reading));
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_read_raw_pin(s_empty_pin, &reading));
 
   while (!s_pin_callback_ran) {
   }


### PR DESCRIPTION
Alright, back at it with another try. This time, the adcChannel defs are the all the same, and I built on top of the library with Gpio Defs. Will check results of PR check but should be all good. 

Overview of changes:
Adc.h
- Added wrappers for all current functions so that they can be called with gpioAddresses 
- Added compound literal gpioAddresses for adc internal channels (REF, TEMP, BAT)
- Added new Gpio AdcPinCallback typedef to allow funcs with gpios as params to be registered with register_callback_pin func
Adc.c
- Added new static AdcPinInterrupt array to keep track of registered callbacks and readings, ensured that although registered callbacks may exist in either AdcPinInterrupt or AdcInterrupt array, only one can be registered per channel
- Adjusted logic of ADC1_COMP_IRQHandler() to check which type of callback is registered, so that it can call with the right params
- Added x86 functionality
Test_adc.c
- Added tests for new functions using same logic as those used for adcchannel functions
