### PR TITLE
[SOFT-301] race condition x86 can

### DIFF
--- a/libraries/ms-common/rules.mk
+++ b/libraries/ms-common/rules.mk
@@ -9,4 +9,5 @@ $(T)_DEPS := $(PLATFORM_LIB) libcore
 
 ifeq (x86,$(PLATFORM))
 $(T)_EXCLUDE_TESTS := pwm pwm_input
+$(T)_CFLAGS += -DX86
 endif

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -21,12 +21,13 @@
 #include "log.h"
 #include "soft_timer.h"
 
-#define CAN_BUS_OFF_RECOVERY_TIME_MS 500  
+#define CAN_BUS_OFF_RECOVERY_TIME_MS 500
 
+//flag enabled if x86 passed as platform
 #ifdef X86
-  #define TX_CALLBACK_ENABLE 0
-#else 
-  #define TX_CALLBACK_ENABLE 1
+#define TX_CALLBACK_ENABLE 0
+#else
+#define TX_CALLBACK_ENABLE 1
 #endif
 
 // Attempts to transmit the specified message using the HW TX, overwriting the
@@ -109,7 +110,7 @@ StatusCode can_register_rx_default_handler(CanRxHandlerCb handler, void *context
   return can_rx_register_default_handler(&s_can_storage->rx_handlers, handler, context);
 }
 
-StatusCode can_register_rx_handler(CanMessageId msg_id, CanRxHandlerCb handler, void *context) {
+StatusCode  can_register_rx_handler(CanMessageId msg_id, CanRxHandlerCb handler, void *context) {
   if (s_can_storage == NULL) {
     return status_code(STATUS_CODE_UNINITIALIZED);
   }
@@ -151,7 +152,7 @@ bool can_process_event(const Event *e) {
 }
 
 void prv_tx_handler(void *context) {
-  if(TX_CALLBACK_ENABLE) {
+  if (TX_CALLBACK_ENABLE) {
     CanStorage *can_storage = context;
     CanMessage tx_msg;
     // If we failed to TX some messages or aren't transmitting fast enough, those

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -21,7 +21,13 @@
 #include "log.h"
 #include "soft_timer.h"
 
-#define CAN_BUS_OFF_RECOVERY_TIME_MS 500
+#define CAN_BUS_OFF_RECOVERY_TIME_MS 500  
+
+#ifdef X86
+  #define TX_CALLBACK_ENABLE 0
+#else 
+  #define TX_CALLBACK_ENABLE 1
+#endif
 
 // Attempts to transmit the specified message using the HW TX, overwriting the
 // source device.
@@ -145,14 +151,15 @@ bool can_process_event(const Event *e) {
 }
 
 void prv_tx_handler(void *context) {
-  CanStorage *can_storage = context;
-  CanMessage tx_msg;
-
-  // If we failed to TX some messages or aren't transmitting fast enough, those
-  // events were discarded. Raise a TX event to trigger a transmit attempt. We
-  // only raise one event since TX ready interrupts are 1-to-1.
-  if (can_fifo_size(&can_storage->tx_fifo) > 0) {
-    event_raise(can_storage->tx_event, 0);
+  if(TX_CALLBACK_ENABLE) {
+    CanStorage *can_storage = context;
+    CanMessage tx_msg;
+    // If we failed to TX some messages or aren't transmitting fast enough, those
+    // events were discarded. Raise a TX event to trigger a transmit attempt. We
+    // only raise one event since TX ready interrupts are 1-to-1.
+    if (can_fifo_size(&can_storage->tx_fifo) > 0) {
+      event_raise(can_storage->tx_event, 0);
+    }
   }
 }
 

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -25,9 +25,9 @@
 
 // flag enabled if x86 passed as platform
 #ifdef X86
-#define TX_CALLBACK_ENABLE 0
+#define TX_CALLBACK_ENABLE false
 #else
-#define TX_CALLBACK_ENABLE 1
+#define TX_CALLBACK_ENABLE true
 #endif
 
 // Attempts to transmit the specified message using the HW TX, overwriting the
@@ -152,6 +152,8 @@ bool can_process_event(const Event *e) {
 }
 
 void prv_tx_handler(void *context) {
+  // following condition used to disable tx events being re-raised on x86
+  // as this causes a race condition: see soft_301_race_condition_x86_can
   if (TX_CALLBACK_ENABLE) {
     CanStorage *can_storage = context;
     CanMessage tx_msg;

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -153,7 +153,7 @@ bool can_process_event(const Event *e) {
 
 void prv_tx_handler(void *context) {
   // following condition used to disable tx events being re-raised on x86
-  // as this causes a race condition: see soft_301_race_condition_x86_can
+  // as this causes a race condition: see SOFT-301
   if (TX_CALLBACK_ENABLE) {
     CanStorage *can_storage = context;
     CanMessage tx_msg;

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -23,7 +23,7 @@
 
 #define CAN_BUS_OFF_RECOVERY_TIME_MS 500
 
-//flag enabled if x86 passed as platform
+// flag enabled if x86 passed as platform
 #ifdef X86
 #define TX_CALLBACK_ENABLE 0
 #else
@@ -110,7 +110,7 @@ StatusCode can_register_rx_default_handler(CanRxHandlerCb handler, void *context
   return can_rx_register_default_handler(&s_can_storage->rx_handlers, handler, context);
 }
 
-StatusCode  can_register_rx_handler(CanMessageId msg_id, CanRxHandlerCb handler, void *context) {
+StatusCode can_register_rx_handler(CanMessageId msg_id, CanRxHandlerCb handler, void *context) {
   if (s_can_storage == NULL) {
     return status_code(STATUS_CODE_UNINITIALIZED);
   }

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -1,4 +1,3 @@
-#include <inttypes.h>
 #include "can.h"
 #include "delay.h"
 #include "event_queue.h"

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -281,7 +281,7 @@ void test_can_default(void) {
 }
 
 // tests used to fix race condition caused on x86 builds
-// see ticket -> soft_301_race_condition_x86_can
+// see ticket -> SOFT-301
 // txes and rxes 10 messages to make sure same number of each are created
 void test_can_x86_tx(void) {
   volatile CanMessage rx_msg = { 0 };

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -1,4 +1,5 @@
 #include "can.h"
+#include <inttypes.h>
 #include "event_queue.h"
 #include "interrupt.h"
 #include "log.h"
@@ -7,6 +8,9 @@
 
 #define TEST_CAN_UNKNOWN_MSG_ID 0xA
 #define TEST_CAN_DEVICE_ID 0x1
+
+static uint8_t s_rx_cb_count;
+
 
 typedef enum {
   TEST_CAN_EVENT_RX = 10,
@@ -23,7 +27,15 @@ static StatusCode prv_rx_callback(const CanMessage *msg, void *context, CanAckSt
   if (msg->msg_id == TEST_CAN_UNKNOWN_MSG_ID) {
     *ack_reply = CAN_ACK_STATUS_UNKNOWN;
   }
+  LOG_DEBUG("CALLBACK CALLED\n");
+  return STATUS_CODE_OK;
+}
 
+static StatusCode prv_86_rx_callback(const CanMessage *msg, void *context, CanAckStatus *ack_reply) {
+  CanMessage *rx_msg = context;
+  *rx_msg = *msg;
+  s_rx_cb_count++;
+  LOG_DEBUG("CALLBACK CALLED\n");
   return STATUS_CODE_OK;
 }
 
@@ -276,34 +288,36 @@ void test_can_default(void) {
   TEST_ASSERT_EQUAL(msg.data, rx_msg.data);
 }
 
-#if 1
+#ifdef X86
 void test_can_x86_tx(void) {
   volatile CanMessage rx_msg = { 0 };
-  can_register_rx_handler(0x6, prv_rx_callback, &rx_msg);
   CanMessage msg = {
-    .msg_id = 0x1,              //
+    .msg_id = 0x2,              //
     .type = CAN_MSG_TYPE_DATA,  //
     .data = 0x1,                //
     .dlc = 1,                   //
   };
 
-  can_register_rx_default_handler(prv_rx_callback, &rx_msg);
-
-  for(uint8_t i = 0x1; i < 0xA; i++) {
+  can_register_rx_handler(0x2, prv_86_rx_callback, &rx_msg);
+  s_rx_cb_count = 0;
+  for (uint8_t i = 0x0; i < 0xA; i++) {
     msg.data = i;
-    StatusCode ret = can_transmit(&msg, NULL);
-    TEST_ASSERT_OK(ret);
+    can_transmit(&msg, NULL);
     prv_clock_tx();
+    LOG_DEBUG("MESSAGE %" PRIu64 " Sent \n", msg.data);
   }
 
   Event e = { 0 };
   // Handle message RX
-  for(uint8_t i = 0; i < 10; i++) {
-    event_process(&e);
-    bool processed = can_process_event(&e);
-    LOG_DEBUG("MSG ID IS: %x\n", e.data);
-    //TEST_ASSERT_TRUE(processed);
-  }
-  //TEST_ASSERT_FALSE(can_process_event(&e));
+  uint8_t count = 0;
+  while (count < 20) {
+    while(event_process(&e) != STATUS_CODE_OK) {
+    }
+    if(can_process_event(&e)) {
+        count++;
+        LOG_DEBUG("MSG ID IS: %" PRIu64 "\n", rx_msg.data);
+    }
+  }  
+  LOG_DEBUG("COUNT: %d", s_rx_cb_count);
 }
 #endif

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -275,3 +275,35 @@ void test_can_default(void) {
   TEST_ASSERT_EQUAL(msg.msg_id, rx_msg.msg_id);
   TEST_ASSERT_EQUAL(msg.data, rx_msg.data);
 }
+
+#if 1
+void test_can_x86_tx(void) {
+  volatile CanMessage rx_msg = { 0 };
+  can_register_rx_handler(0x6, prv_rx_callback, &rx_msg);
+  CanMessage msg = {
+    .msg_id = 0x1,              //
+    .type = CAN_MSG_TYPE_DATA,  //
+    .data = 0x1,                //
+    .dlc = 1,                   //
+  };
+
+  can_register_rx_default_handler(prv_rx_callback, &rx_msg);
+
+  for(uint8_t i = 0x1; i < 0xA; i++) {
+    msg.data = i;
+    StatusCode ret = can_transmit(&msg, NULL);
+    TEST_ASSERT_OK(ret);
+    prv_clock_tx();
+  }
+
+  Event e = { 0 };
+  // Handle message RX
+  for(uint8_t i = 0; i < 10; i++) {
+    event_process(&e);
+    bool processed = can_process_event(&e);
+    LOG_DEBUG("MSG ID IS: %x\n", e.data);
+    //TEST_ASSERT_TRUE(processed);
+  }
+  //TEST_ASSERT_FALSE(can_process_event(&e));
+}
+#endif

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -286,7 +286,7 @@ void test_can_default(void) {
 void test_can_x86_tx(void) {
   volatile CanMessage rx_msg = { 0 };
   CanMessage msg = {
-    .msg_id = 0x3F,              //
+    .msg_id = 0x3F,             //
     .type = CAN_MSG_TYPE_DATA,  //
     .data = 0x1,                //
     .dlc = 1,                   //

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -1,3 +1,4 @@
+
 #include "can.h"
 #include "delay.h"
 #include "event_queue.h"
@@ -307,7 +308,7 @@ void test_can_x86_tx(void) {
     if (e.id == TEST_CAN_EVENT_TX) {
       tx_msg_count++;
     }
-    delay_ms(100);
+    delay_ms(10);
     if (e.id == TEST_CAN_EVENT_RX) {
       rx_msg_count++;
     }

--- a/projects/smoke_can/src/main.c
+++ b/projects/smoke_can/src/main.c
@@ -41,7 +41,7 @@ static void prv_can_transmit(SoftTimerId timer_id, void *context) {
                          .dlc = 8 };
   can_transmit(&message, NULL);
 
-  //soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
+  // soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
 }
 
 static StatusCode prv_rx_callback(const CanMessage *msg, void *context, CanAckStatus *ack_reply) {
@@ -83,7 +83,7 @@ int main() {
                          .data_u8 = DATA,
                          .type = CAN_MSG_TYPE_DATA,
                          .dlc = 8 };
-  for(int i = 0; i< 10 i++) {
+  for (int i = 0; i < 10 i++) {
     can_transmit(&message, NULL);
   }
 

--- a/projects/smoke_can/src/main.c
+++ b/projects/smoke_can/src/main.c
@@ -18,7 +18,7 @@
 
 // this is how often the message will send
 // modify if you want to send more or less
-#define SMOKETEST_SEND_TIME_MS 10
+#define SMOKETEST_SEND_TIME_MS 1000
 // this is the data it'll send
 // this is an array of exactly 8 uint8_ts
 // change if you wish
@@ -41,7 +41,7 @@ static void prv_can_transmit(SoftTimerId timer_id, void *context) {
                          .dlc = 8 };
   can_transmit(&message, NULL);
 
-  // soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
+  soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
 }
 
 static StatusCode prv_rx_callback(const CanMessage *msg, void *context, CanAckStatus *ack_reply) {
@@ -78,14 +78,6 @@ int main() {
   LOG_DEBUG("Initializing smoke test can\n");
 
   soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
-  CanMessage message = { .source_id = TEST_CAN_DEVICE_ID,
-                         .msg_id = TEST_CAN_MSG_ID,
-                         .data_u8 = DATA,
-                         .type = CAN_MSG_TYPE_DATA,
-                         .dlc = 8 };
-  for (int i = 0; i < 10 i++) {
-    can_transmit(&message, NULL);
-  }
 
   Event e = { 0 };
   while (true) {

--- a/projects/smoke_can/src/main.c
+++ b/projects/smoke_can/src/main.c
@@ -18,7 +18,7 @@
 
 // this is how often the message will send
 // modify if you want to send more or less
-#define SMOKETEST_SEND_TIME_MS 1000
+#define SMOKETEST_SEND_TIME_MS 10
 // this is the data it'll send
 // this is an array of exactly 8 uint8_ts
 // change if you wish
@@ -41,7 +41,7 @@ static void prv_can_transmit(SoftTimerId timer_id, void *context) {
                          .dlc = 8 };
   can_transmit(&message, NULL);
 
-  soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
+  //soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
 }
 
 static StatusCode prv_rx_callback(const CanMessage *msg, void *context, CanAckStatus *ack_reply) {
@@ -78,6 +78,14 @@ int main() {
   LOG_DEBUG("Initializing smoke test can\n");
 
   soft_timer_start_millis(SMOKETEST_SEND_TIME_MS, prv_can_transmit, NULL, NULL);
+  CanMessage message = { .source_id = TEST_CAN_DEVICE_ID,
+                         .msg_id = TEST_CAN_MSG_ID,
+                         .data_u8 = DATA,
+                         .type = CAN_MSG_TYPE_DATA,
+                         .dlc = 8 };
+  for(int i = 0; i< 10 i++) {
+    can_transmit(&message, NULL);
+  }
 
   Event e = { 0 };
   while (true) {


### PR DESCRIPTION
added flag to check if X86 is defined and not execute body of prv_tx_callback in can.c if it is. 
Wrote requisite test as well.