### PR TITLE
[SOFT-340] Check for invalid timer ID in soft_timer_remaining_time

### DIFF
--- a/libraries/ms-common/inc/soft_timer.h
+++ b/libraries/ms-common/inc/soft_timer.h
@@ -43,6 +43,6 @@ bool soft_timer_cancel(SoftTimerId timer_id);
 bool soft_timer_inuse(void);
 
 // Checks the time left on a particular timer. Returns a 0 if the timer has
-// expired and is no longer in use. Note that since timer ids are re-used this
-// could return false values once the timer has expired or if it is cancelled.
+// expired and is no longer in use, or if timer_id is invalid. Note that since timer ids are re-used
+// this could return false values once the timer has expired or if it is cancelled.
 uint32_t soft_timer_remaining_time(SoftTimerId timer_id);

--- a/libraries/ms-common/src/stm32f0xx/soft_timer.c
+++ b/libraries/ms-common/src/stm32f0xx/soft_timer.c
@@ -101,6 +101,10 @@ bool soft_timer_inuse(void) {
 }
 
 uint32_t soft_timer_remaining_time(SoftTimerId timer_id) {
+  if (timer_id >= SOFT_TIMER_MAX_TIMERS) {
+    return 0;
+  }
+
   if (s_storage[timer_id].expiry_us == 0) {
     return 0;
   }

--- a/libraries/ms-common/src/x86/soft_timer.c
+++ b/libraries/ms-common/src/x86/soft_timer.c
@@ -136,6 +136,10 @@ bool soft_timer_cancel(SoftTimerId timer_id) {
 }
 
 uint32_t soft_timer_remaining_time(SoftTimerId timer_id) {
+  if (timer_id >= SOFT_TIMER_MAX_TIMERS) {
+    return 0;
+  }
+
   struct itimerspec spec = { { 0, 0 }, { 0, 0 } };
   timer_gettime(s_posix_timers[timer_id].timer_id, &spec);
   return spec.it_value.tv_sec * 1000000 + spec.it_value.tv_nsec / 1000;

--- a/libraries/ms-common/test/test_soft_timer.c
+++ b/libraries/ms-common/test/test_soft_timer.c
@@ -164,6 +164,12 @@ void test_soft_timer_remaining(void) {
   TEST_ASSERT_FALSE(soft_timer_inuse());
 }
 
+// Make sure passing in an invalid timer id to soft_timer_remaining_time doesn't cause a segfault
+void test_soft_timer_remaining_invalid_id(void) {
+  SoftTimerId test_timer_id = SOFT_TIMER_INVALID_TIMER;
+  TEST_ASSERT_EQUAL(0, soft_timer_remaining_time(test_timer_id));
+}
+
 void test_soft_timer_exhausted(void) {
   volatile SoftTimerId cb_ids[SOFT_TIMER_MAX_TIMERS] = { 0 };
   volatile SoftTimerId cb_id_single = SOFT_TIMER_INVALID_TIMER;


### PR DESCRIPTION
In `soft_timer.c`, `soft_timer_remaining_time` will segfault when called with an invalid timer ID (anything >= SOFT_TIMER_INVALID_TIMER) since it doesn't perform bounds checking on the `timer_id` passed in, unlike in `soft_timer_cancel`.  

Since we tend to set timer IDs to SOFT_TIMER_INVALID_TIMER after they've finished/been cancelled (ex/ in `bts_7200_current_sense.c`), using `soft_timer_remaining_time` to check if these timers have finished could cause issues, and workarounds will likely complicate the FW.

This PR adds a check for this in the x86 and STM32 implementations of `soft_timer_remaining_time`, as well as a quick test to make sure segfaults don't happen anymore.