### PR TITLE
[SOFT-347] Fix ADC returning old values on STM32

### DIFF
--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -55,10 +55,13 @@ StatusCode adc_set_channel_pin(GpioAddress address, bool new_state);
 // completes a conversion
 StatusCode adc_register_callback_pin(GpioAddress address, AdcPinCallback callback, void *context);
 
+// Do not call |adc_read_raw/converted| or |adc_read_raw/converted_pin| from an interrupt callback
+// with INTERRUPT_PRIORITY_HIGH, as it will cause deadlock.
+
 // Obtain the raw 12-bit value read by the specified pin
 StatusCode adc_read_raw_pin(GpioAddress address, uint16_t *reading);
 
-// Obtain the converted value at the specified pin
+// Obtain the converted value at the specified pin, in mV
 StatusCode adc_read_converted_pin(GpioAddress address, uint16_t *reading);
 
 // Following code and functions use adc channels as seen below
@@ -83,5 +86,5 @@ StatusCode adc_register_callback(AdcChannel adc_channel, AdcCallback callback, v
 StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading);
 
 // Deprecated in favour of GpioAddress version
-// Obtain the converted value at the specified channel
+// Obtain the converted value at the specified channel, in mV
 StatusCode adc_read_converted(AdcChannel adc_channel, uint16_t *reading);


### PR DESCRIPTION
The STM32 version of `adc.c` would return old values from `adc_read_raw` (probably/especially when called form within a soft timer). This is because to block until the ADC reading was ready, we would wait for the EOSEQ (end-of-sequence) bit to change from 1 to 0. However, the EOSEQ bit is always 0 until the end of the sequence, at which point it changes to 1; however, the ADC IRQHandler (interrupt handler) is called whenever EOSEQ changes to 1 and resets it to 0 before the blocking while loop can see the EOSEQ value. Thus, we would just never block, and adding a `!` wouldn't fix it.

The fix is to track whether we're currently converting on our own with a `volatile bool` and wait on that instead.

Also added a notice about not using it from a high-priority interrupt since that'll cause deadlock (caused by the NVIC queuing the ADC interrupt, which is also high priority, to after the calling interrupt finishes), and clarified the unit of the readings from `adc_read_converted`/`adc_read_converted_pin`.