### PR TITLE
[SOFT-350] Improve the mux driver

### DIFF
--- a/libraries/ms-drivers/inc/mux.h
+++ b/libraries/ms-drivers/inc/mux.h
@@ -1,6 +1,6 @@
 #pragma once
 
-// GPIO interface to an arbitrary-bit multiplexer like SN74LV4051AQPWRQ1 or CD74HC4067.
+// GPIO interface to an arbitrary-bit multiplexer or demultiplexer.
 // Requires GPIO to be initialized.
 
 #include "gpio.h"
@@ -11,13 +11,9 @@
 typedef struct {
   uint8_t bit_width;
   GpioAddress sel_pins[MAX_MUX_BIT_WIDTH];
-  GpioAddress mux_output_pin;
-  GpioAddress mux_enable_pin;
 } MuxAddress;
 
-// Initialize all the pins of the given mux.
-// Note: this will initialize the mux_output_pin as input with GPIO_ALTFN_NONE. If you want a
-// different configuration, reinitialize it. (Arshan what should I do)
+// Initialize all the select pins of the given mux.
 StatusCode mux_init(MuxAddress *address);
 
 // Set the select pins to get the specified pin.

--- a/libraries/ms-drivers/src/mux.c
+++ b/libraries/ms-drivers/src/mux.c
@@ -17,22 +17,6 @@ StatusCode mux_init(MuxAddress *address) {
     status_ok_or_return(gpio_init_pin(&address->sel_pins[i], &select_settings));
   }
 
-  // initialize the mux output pin
-  GpioSettings mux_output_settings = {
-    .direction = GPIO_DIR_IN,  // what if we want to initialize it with GPIO_ALTFN_ANALOG?
-    .alt_function = GPIO_ALTFN_NONE,
-  };
-  status_ok_or_return(gpio_init_pin(&address->mux_output_pin, &mux_output_settings));
-
-  // initialize the enable pin to high
-  GpioSettings mux_enable_settings = {
-    .direction = GPIO_DIR_OUT,
-    .state = GPIO_STATE_HIGH,
-    .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_NONE,
-  };
-  status_ok_or_return(gpio_init_pin(&address->mux_enable_pin, &mux_output_settings));
-
   return STATUS_CODE_OK;
 }
 

--- a/libraries/ms-drivers/test/test_mux.c
+++ b/libraries/ms-drivers/test/test_mux.c
@@ -19,8 +19,6 @@ void test_mux_init_valid(void) {
             { .port = GPIO_PORT_A, .pin = 4 },  //
             { .port = GPIO_PORT_A, .pin = 3 },  //
         },
-    .mux_output_pin = { .port = GPIO_PORT_B, .pin = 0 },
-    .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },
   };
   TEST_ASSERT_OK(mux_init(&valid_address));
 }
@@ -35,12 +33,7 @@ void test_mux_init_invalid(void) {
             { .port = GPIO_PORT_A, .pin = 5 },     //
             { .port = GPIO_PORT_A, .pin = 4 },     //
         },
-    .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },
-    .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },
   };
-  TEST_ASSERT_NOT_OK(mux_init(&invalid_address));
-  invalid_address.sel_pins[0].port = GPIO_PORT_A;
-  invalid_address.mux_output_pin.port = NUM_GPIO_PORTS;
   TEST_ASSERT_NOT_OK(mux_init(&invalid_address));
 }
 
@@ -64,8 +57,6 @@ void test_mux_set_valid(void) {
             { .port = GPIO_PORT_A, .pin = 4 },  //
             { .port = GPIO_PORT_A, .pin = 3 },  //
         },
-    .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },
-    .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },
   };
   TEST_ASSERT_OK(mux_init(&address));
   TEST_ASSERT_OK(mux_set(&address, 0));
@@ -84,8 +75,6 @@ void test_mux_set_invalid_selection(void) {
             { .port = GPIO_PORT_A, .pin = 4 },  //
             { .port = GPIO_PORT_A, .pin = 3 },  //
         },
-    .mux_output_pin = { .port = GPIO_PORT_B, .pin = 0 },
-    .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },
   };
   TEST_ASSERT_OK(mux_init(&address));
 

--- a/projects/power_distribution/inc/current_measurement.h
+++ b/projects/power_distribution/inc/current_measurement.h
@@ -64,6 +64,8 @@ typedef struct {
   uint8_t num_bts7040_channels;  // length of preceding array
 
   MuxAddress mux_address;
+  GpioAddress mux_output_pin;
+  GpioAddress mux_enable_pin;
 } PowerDistributionCurrentHardwareConfig;
 
 typedef struct {

--- a/projects/power_distribution/src/current_measurement.c
+++ b/projects/power_distribution/src/current_measurement.c
@@ -55,12 +55,29 @@ StatusCode power_distribution_current_measurement_init(PowerDistributionCurrentS
   }
   status_ok_or_return(mux_init(&s_hw_config.mux_address));
 
+  // initialize the mux enable pin to low - CD74HC4067M96's enable pin is active-low
+  GpioSettings mux_enable_pin_settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_NONE,
+  };
+  status_ok_or_return(gpio_init_pin(&s_hw_config.mux_enable_pin, &mux_enable_pin_settings));
+
+  // initialize the mux output pin as an ADC input
+  GpioSettings mux_output_pin_settings = {
+    .direction = GPIO_DIR_IN,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_ANALOG,
+  };
+  status_ok_or_return(gpio_init_pin(&s_hw_config.mux_output_pin, &mux_output_pin_settings));
+
   // note: we don't have to initialize the mux_output_pin as ADC because
   // bts7200_init_pca9539r and bts7040_init do it for us
 
   // initialize and start the BTS7200s
   Bts7200Pca9539rSettings bts7200_settings = {
-    .sense_pin = &s_hw_config.mux_address.mux_output_pin,
+    .sense_pin = &s_hw_config.mux_output_pin,
   };
 
   for (uint8_t i = 0; i < s_hw_config.num_bts7200_channels; i++) {
@@ -87,7 +104,7 @@ StatusCode power_distribution_current_measurement_init(PowerDistributionCurrentS
 
   // initialize all BTS7040/7008s
   Bts7040Pca9539rSettings bts7040_settings = {
-    .sense_pin = &s_hw_config.mux_address.mux_output_pin,
+    .sense_pin = &s_hw_config.mux_output_pin,
   };
   for (uint8_t i = 0; i < s_hw_config.num_bts7040_channels; i++) {
     // check that the current is valid

--- a/projects/power_distribution/src/current_measurement.c
+++ b/projects/power_distribution/src/current_measurement.c
@@ -64,14 +64,6 @@ StatusCode power_distribution_current_measurement_init(PowerDistributionCurrentS
   };
   status_ok_or_return(gpio_init_pin(&s_hw_config.mux_enable_pin, &mux_enable_pin_settings));
 
-  // initialize the mux output pin as an ADC input
-  GpioSettings mux_output_pin_settings = {
-    .direction = GPIO_DIR_IN,
-    .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_ANALOG,
-  };
-  status_ok_or_return(gpio_init_pin(&s_hw_config.mux_output_pin, &mux_output_pin_settings));
-
   // note: we don't have to initialize the mux_output_pin as ADC because
   // bts7200_init_pca9539r and bts7040_init do it for us
 

--- a/projects/power_distribution/src/current_measurement_config.c
+++ b/projects/power_distribution/src/current_measurement_config.c
@@ -123,9 +123,9 @@ const PowerDistributionCurrentHardwareConfig FRONT_POWER_DISTRIBUTION_CURRENT_HW
                   { .port = GPIO_PORT_A, .pin = 4 },  //
                   { .port = GPIO_PORT_A, .pin = 3 },  //
               },
-          .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
-          .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
       },
+  .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
+  .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
 };
 
 // This is based on https://uwmidsun.atlassian.net/wiki/x/GgODP, assuming that the currents in
@@ -250,7 +250,7 @@ const PowerDistributionCurrentHardwareConfig REAR_POWER_DISTRIBUTION_CURRENT_HW_
                   { .port = GPIO_PORT_A, .pin = 4 },  //
                   { .port = GPIO_PORT_A, .pin = 3 },  //
               },
-          .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
-          .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
       },
+  .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
+  .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
 };

--- a/projects/power_distribution/test/test_current_measurement.c
+++ b/projects/power_distribution/test/test_current_measurement.c
@@ -171,9 +171,9 @@ void test_power_distribution_current_measurement_invalid_hw_config(void) {
                     { .port = GPIO_PORT_A, .pin = 2 },  //
                     { .port = GPIO_PORT_A, .pin = 3 },  //
                 },
-            .mux_output_pin = { .port = GPIO_PORT_A, .pin = 0 },  //
-            .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 1 },  //
         },
+    .mux_output_pin = { .port = GPIO_PORT_A, .pin = 0 },  //
+    .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 1 },  //
   };
   PowerDistributionCurrentSettings settings = {
     .interval_us = 2000,
@@ -214,14 +214,14 @@ void test_power_distribution_current_measurement_invalid_hw_config(void) {
   settings.hw_config.mux_address.sel_pins[0].port = GPIO_PORT_A;
 
   // invalid mux output pin
-  settings.hw_config.mux_address.mux_output_pin.port = NUM_GPIO_PORTS;
+  settings.hw_config.mux_output_pin.port = NUM_GPIO_PORTS;
   TEST_ASSERT_NOT_OK(power_distribution_current_measurement_init(&settings));
-  settings.hw_config.mux_address.mux_output_pin.port = GPIO_PORT_A;
+  settings.hw_config.mux_output_pin.port = GPIO_PORT_A;
 
   // invalid mux enable pin
-  settings.hw_config.mux_address.mux_enable_pin.port = NUM_GPIO_PORTS;
+  settings.hw_config.mux_enable_pin.port = NUM_GPIO_PORTS;
   TEST_ASSERT_NOT_OK(power_distribution_current_measurement_init(&settings));
-  settings.hw_config.mux_address.mux_enable_pin.port = GPIO_PORT_A;
+  settings.hw_config.mux_enable_pin.port = GPIO_PORT_A;
 
   // otherwise valid
   TEST_ASSERT_OK(power_distribution_current_measurement_init(&settings));

--- a/projects/smoke_bts7200/inc/current_measurement_config.h
+++ b/projects/smoke_bts7200/inc/current_measurement_config.h
@@ -2,8 +2,8 @@
 
 // Standard hardware configurations for current_measurement.
 
-// #include "current_measurement.h"
 #include <stdint.h>
+
 #include "gpio.h"
 #include "mux.h"
 #include "pca9539r_gpio_expander.h"
@@ -25,6 +25,8 @@ typedef struct {
   uint8_t num_bts7200_channels;  // length of preceding array
 
   MuxAddress mux_address;
+  GpioAddress mux_output_pin;
+  GpioAddress mux_enable_pin;
 } PowerDistributionCurrentHardwareConfig;
 
 extern const PowerDistributionCurrentHardwareConfig FRONT_POWER_DISTRIBUTION_CURRENT_HW_CONFIG;

--- a/projects/smoke_bts7200/src/current_measurement_config.c
+++ b/projects/smoke_bts7200/src/current_measurement_config.c
@@ -59,9 +59,9 @@ const PowerDistributionCurrentHardwareConfig FRONT_POWER_DISTRIBUTION_CURRENT_HW
                   { .port = GPIO_PORT_A, .pin = 4 },  //
                   { .port = GPIO_PORT_A, .pin = 3 },  //
               },
-          .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
-          .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
       },
+  .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
+  .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
 };
 
 // This is based on https://uwmidsun.atlassian.net/wiki/x/GgODP, assuming that the currents in
@@ -120,7 +120,7 @@ const PowerDistributionCurrentHardwareConfig REAR_POWER_DISTRIBUTION_CURRENT_HW_
                   { .port = GPIO_PORT_A, .pin = 4 },  //
                   { .port = GPIO_PORT_A, .pin = 3 },  //
               },
-          .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
-          .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
       },
+  .mux_output_pin = { .port = GPIO_PORT_A, .pin = 7 },  //
+  .mux_enable_pin = { .port = GPIO_PORT_A, .pin = 2 },  //
 };

--- a/projects/smoke_bts7200/src/main.c
+++ b/projects/smoke_bts7200/src/main.c
@@ -2,14 +2,16 @@
 
 // Periodically take reading from user selected channels and log the result
 // Configurable items: wait time, FRONT or REAR power distro selection, channels to be tested
-#include "bts7200_load_switch.h"
-#include "current_measurement_config.h"
-#include "pca9539r_gpio_expander.h"
 
+#include "bts7200_load_switch.h"
+#include "controller_board_pins.h"
+#include "current_measurement_config.h"
 #include "gpio.h"
+#include "i2c.h"
 #include "interrupt.h"
 #include "log.h"
 #include "mux.h"
+#include "pca9539r_gpio_expander.h"
 #include "soft_timer.h"
 #include "wait.h"
 
@@ -20,6 +22,11 @@
 // Maximum number of channels that can be tested,
 // which is the same number of bts7200 used in front/rear power distribution
 #define MAX_TEST_CHANNELS 8
+
+#define I2C_PORT I2C_PORT_2
+#define PIN_I2C_SCL CONTROLLER_BOARD_ADDR_I2C2_SCL
+#define PIN_I2C_SDA CONTROLLER_BOARD_ADDR_I2C2_SDA
+
 // Set of channels to be tested, the array contains the indices of the BTS7200 in the front/rear HW
 // config Details at
 // https://uwmidsun.atlassian.net/wiki/spaces/ELEC/pages/1419740028/BTS7200+smoke+test+user+guide
@@ -45,6 +52,13 @@ int main() {
   gpio_init();
   interrupt_init();
   soft_timer_init();
+  adc_init(ADC_MODE_SINGLE);
+  I2CSettings i2c_settings = {
+    .speed = I2C_SPEED_FAST,
+    .sda = PIN_I2C_SDA,
+    .scl = PIN_I2C_SCL,
+  };
+  i2c_init(I2C_PORT, &i2c_settings);
 
   PowerDistributionCurrentHardwareConfig s_hw_config =
       IS_FRONT_POWER_DISTRO ? FRONT_POWER_DISTRIBUTION_CURRENT_HW_CONFIG
@@ -52,9 +66,18 @@ int main() {
 
   status_ok_or_return(mux_init(&s_hw_config.mux_address));
 
+  // Initialize the mux enable pin to low - CD74HC4067M96's enable pin is active low on power distro
+  GpioSettings mux_enable_pin_settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_NONE,
+  };
+  status_ok_or_return(gpio_init_pin(&s_hw_config.mux_enable_pin, &mux_enable_pin_settings));
+
   // Initialize and start the BTS7200s
   Bts7200Pca9539rSettings bts7200_settings = {
-    .sense_pin = &s_hw_config.mux_address.mux_output_pin,
+    .sense_pin = &s_hw_config.mux_output_pin,
     .i2c_port = s_hw_config.i2c_port,
   };
 
@@ -62,6 +85,16 @@ int main() {
     bts7200_settings.select_pin = &s_hw_config.bts7200s[s_test_channels[i]].dsel_pin;
     status_ok_or_return(bts7200_init_pca9539r(&s_bts7200_storages[i], &bts7200_settings));
   }
+
+  // enabling steering + front left light for convenience in smoke testing
+  Pca9539rGpioAddress steering_en = { .i2c_address = 0x76, .pin = PCA9539R_PIN_IO1_3 };
+  Pca9539rGpioAddress front_left_light_en = { .i2c_address = 0x76, .pin = PCA9539R_PIN_IO0_4 };
+  Pca9539rGpioSettings pca9539r_gpio_settings = {
+    .direction = PCA9539R_GPIO_DIR_OUT,
+    .state = PCA9539R_GPIO_STATE_HIGH,
+  };
+  pca9539r_gpio_init_pin(&steering_en, &pca9539r_gpio_settings);
+  pca9539r_gpio_init_pin(&front_left_light_en, &pca9539r_gpio_settings);
 
   soft_timer_start_millis(CURRENT_MEASURE_INTERVAL_MS, prv_read_and_log, &s_hw_config, NULL);
   while (true) {

--- a/projects/smoke_spv1020/src/main.c
+++ b/projects/smoke_spv1020/src/main.c
@@ -38,17 +38,7 @@
 #define CS_PIN \
   { .port = GPIO_PORT_B, 12 }
 
-// these are for setting the demux enable, outputs, and inputs
-#define MUX_ENABLE                \
-  {                               \
-    .port = GPIO_PORT_B, .pin = 1 \
-  }  // need to check hardward for correct pin
-     // this pin is unused
-#define MUX_OUTPUT                \
-  {                               \
-    .port = GPIO_PORT_B, .pin = 1 \
-  }  // need to check hardward for correct pin
-     // this pin is unused
+// these are for setting the demux inputs
 #define SEL_PIN_0 \
   { .port = GPIO_PORT_B, .pin = 3 }
 #define SEL_PIN_1 \
@@ -64,8 +54,6 @@ static MuxAddress s_mux_address = {
   .sel_pins[0] = SEL_PIN_0,
   .sel_pins[1] = SEL_PIN_1,
   .sel_pins[2] = SEL_PIN_2,
-  .mux_enable_pin = MUX_ENABLE,
-  .mux_output_pin = MUX_OUTPUT,
 };
 
 // this checks the sepcific spv1020

--- a/projects/solar/src/mppt.c
+++ b/projects/solar/src/mppt.c
@@ -11,8 +11,6 @@ static MuxAddress s_mux_address = {
   .sel_pins[0] = MUX_SEL_PIN_0,
   .sel_pins[1] = MUX_SEL_PIN_1,
   .sel_pins[2] = MUX_SEL_PIN_2,
-  .mux_enable_pin = SOLAR_UNUSED_PIN,  // we don't have an accessible enable or output pin
-  .mux_output_pin = SOLAR_UNUSED_PIN,  // but the mux driver needs them to be set
 };
 
 StatusCode mppt_init() {


### PR DESCRIPTION
This just moves ownership of real muxes' enable and output pins from the `mux` driver to the individual project. `mux` is a generic driver whose only function is to write a binary number into GPIO pins. In solar, it was used for a demux which didn't even have enable or output pins, so they had no business being in the driver's control.

This also solves the part of the BTS7200 smoke test issue where the mux enable pin was wrongly high instead of low - power_distribution's `current_measurement` takes care of that now, as does `smoke_bts7200`.

I also took the liberty to incorporate a few of the changes from soft_151_power_distro_validation, so smoke_bts7200 should have half a chance of working now.