### PR TITLE
[SOFT-323] Fix issues with bts7200_stop and bts7040_stop

### DIFF
--- a/libraries/ms-drivers/inc/bts7040_load_switch.h
+++ b/libraries/ms-drivers/inc/bts7040_load_switch.h
@@ -101,5 +101,5 @@ StatusCode bts7040_get_measurement(Bts7040Storage *storage, uint16_t *meas);
 // DO NOT USE if you are reading with bts7040_get_measurement.
 StatusCode bts7040_start(Bts7040Storage *storage);
 
-// Stop the timer associated with the storage and return whether stopping it was successful.
-bool bts7040_stop(Bts7040Storage *storage);
+// Stop the measurement and fault timers associated with the storage.
+void bts7040_stop(Bts7040Storage *storage);

--- a/libraries/ms-drivers/inc/bts7200_load_switch.h
+++ b/libraries/ms-drivers/inc/bts7200_load_switch.h
@@ -117,5 +117,5 @@ bool bts7200_get_output_1_enabled(Bts7200Storage *storage);
 // DO NOT USE if you are reading with bts7200_get_measurement.
 StatusCode bts7200_start(Bts7200Storage *storage);
 
-// Stop the timer associated with the storage and return whether it was successful.
-bool bts7200_stop(Bts7200Storage *storage);
+// Stop the timer and any active fault timers associated with the storage.
+void bts7200_stop(Bts7200Storage *storage);

--- a/libraries/ms-drivers/src/bts7040_load_switch.c
+++ b/libraries/ms-drivers/src/bts7040_load_switch.c
@@ -146,8 +146,8 @@ StatusCode bts7040_start(Bts7040Storage *storage) {
   return STATUS_CODE_OK;
 }
 
-bool bts7040_stop(Bts7040Storage *storage) {
-  bool result = soft_timer_cancel(storage->measurement_timer_id);
+void bts7040_stop(Bts7040Storage *storage) {
+  soft_timer_cancel(storage->measurement_timer_id);
   soft_timer_cancel(storage->enable_pin.fault_timer_id);
 
   // make sure calling stop twice doesn't cancel an unrelated timer
@@ -156,6 +156,4 @@ bool bts7040_stop(Bts7040Storage *storage) {
 
   // Fault handling no longer in progress
   storage->enable_pin.fault_in_progress = false;
-
-  return result;
 }

--- a/libraries/ms-drivers/src/bts7200_load_switch.c
+++ b/libraries/ms-drivers/src/bts7200_load_switch.c
@@ -233,8 +233,8 @@ StatusCode bts7200_start(Bts7200Storage *storage) {
   return STATUS_CODE_OK;
 }
 
-bool bts7200_stop(Bts7200Storage *storage) {
-  bool result = soft_timer_cancel(storage->measurement_timer_id);
+void bts7200_stop(Bts7200Storage *storage) {
+  soft_timer_cancel(storage->measurement_timer_id);
   soft_timer_cancel(storage->enable_pin_0.fault_timer_id);
   soft_timer_cancel(storage->enable_pin_1.fault_timer_id);
   // make sure calling stop twice doesn't cancel an unrelated timer
@@ -245,6 +245,4 @@ bool bts7200_stop(Bts7200Storage *storage) {
   // Fault handling no longer in progress
   storage->enable_pin_0.fault_in_progress = false;
   storage->enable_pin_1.fault_in_progress = false;
-
-  return result;
 }

--- a/libraries/ms-drivers/test/test_bts7040_load_switch.c
+++ b/libraries/ms-drivers/test/test_bts7040_load_switch.c
@@ -120,7 +120,7 @@ void test_bts7040_current_sense_timer_stm32_works(void) {
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 
   // make sure that stop actually stops it
   delay_us(2 * interval_us);
@@ -164,7 +164,7 @@ void test_bts7040_current_sense_timer_pca9539r_works(void) {
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 
   // make sure that stop actually stops it
   delay_us(2 * interval_us);
@@ -201,7 +201,7 @@ void test_bts7040_current_sense_restart(void) {
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 
   // make sure it's stopped
   delay_us(2 * interval_us);
@@ -219,7 +219,7 @@ void test_bts7040_current_sense_restart(void) {
 
   TEST_ASSERT_EQUAL(4, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 
   // make sure it's stopped
   delay_us(2 * interval_us);
@@ -311,7 +311,7 @@ void test_bts7040_current_sense_null_callback(void) {
 
   TEST_ASSERT_OK(bts7040_init_stm32(&s_storage, &settings));
   TEST_ASSERT_OK(bts7040_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 }
 
 // Test that bts7040_get_measurement returns ok.
@@ -361,29 +361,6 @@ void test_bts7040_current_sense_get_measurement_pca9539r_valid(void) {
   LOG_DEBUG("PCA9539R reading: %d\n", reading);
 }
 
-// Test that bts7040_stop returns true only when it stops a timer
-void test_bts7040_current_sense_stop_return_behaviour(void) {
-  // this doesn't matter (adc isn't reading anything) but can't be null
-  GpioAddress test_sense_pin = { .port = GPIO_PORT_A, .pin = 0 };
-  GpioAddress test_enable_pin = { .port = GPIO_PORT_A, .pin = 1 };  // EN pin
-  uint32_t interval_us = 500;                                       // 0.5 ms
-  Bts7040Stm32Settings settings = {
-    .sense_pin = &test_sense_pin,
-    .enable_pin = &test_enable_pin,
-    .interval_us = interval_us,
-    .resistor = BTS7040_TEST_RESISTOR,
-    .min_fault_voltage_mv = ADC_MIN_FAULT_VOLTAGE,
-    .max_fault_voltage_mv = ADC_MAX_FAULT_VOLTAGE,
-    .callback = &prv_callback_increment,
-  };
-
-  TEST_ASSERT_OK(bts7040_init_stm32(&s_storage, &settings));
-  TEST_ASSERT_FALSE(bts7040_stop(&s_storage));
-  TEST_ASSERT_OK(bts7040_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
-  TEST_ASSERT_FALSE(bts7040_stop(&s_storage));
-}
-
 // Test that the context is actually passed to the function
 void test_bts7040_current_sense_context_passed(void) {
   // this doesn't matter (adc isn't reading anything) but can't be null
@@ -405,7 +382,7 @@ void test_bts7040_current_sense_context_passed(void) {
 
   TEST_ASSERT_OK(bts7040_init_stm32(&s_storage, &settings));
   TEST_ASSERT_OK(bts7040_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
   TEST_ASSERT_EQUAL(context_pointer, s_received_context);
 }
 
@@ -455,7 +432,7 @@ void test_bts7040_output_functions_work(void) {
   TEST_ASSERT_FALSE(bts7040_get_output_enabled(&s_storage));
 
   // Stop
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 }
 
 // Test that fault callback gets called when measurement is within fault range.
@@ -514,8 +491,6 @@ void test_bts7040_no_fault_outside_of_fault_range(void) {
   bts7040_get_measurement(&s_storage, &meas);
 
   TEST_ASSERT_EQUAL(0, s_times_fault_callback_called);
-
-  s_times_fault_callback_called = 0;
 }
 
 // Test that the fault callback gets called when running bts7040_start, and
@@ -544,8 +519,7 @@ void test_bts7040_fault_cb_called_from_start(void) {
   s_adc_measurement = ADC_FAULT_VOLTAGE;
   delay_us(2 * interval_us);  // wait for 2* interval
   TEST_ASSERT_TRUE(s_times_fault_callback_called > 0);
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
-  s_times_fault_callback_called = 0;
+  bts7040_stop(&s_storage);
 }
 
 // Test that fault cleared correctly, and that the IN pin is toggled
@@ -592,7 +566,7 @@ void test_bts7040_handle_fault_clears_fault(void) {
   delay_ms(40);
   TEST_ASSERT_TRUE(bts7040_get_output_enabled(&s_storage));
 
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 }
 
 // Test that fault context is passed on correctly on fault.
@@ -672,7 +646,7 @@ void test_bts7040_enable_fails_during_fault(void) {
   TEST_ASSERT_TRUE(bts7040_get_output_enabled(&s_storage));
 
   // Stop
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 }
 
 // Make sure that bts7040_stop stops all soft timers and sets
@@ -708,7 +682,7 @@ void test_bts7040_stop_works(void) {
   TEST_ASSERT_TRUE(soft_timer_remaining_time(s_storage.enable_pin.fault_timer_id) > 0);
 
   // Stop
-  TEST_ASSERT_TRUE(bts7040_stop(&s_storage));
+  bts7040_stop(&s_storage);
 
   // Verify
   TEST_ASSERT_EQUAL(SOFT_TIMER_INVALID_TIMER, s_storage.measurement_timer_id);

--- a/libraries/ms-drivers/test/test_bts7200_load_switch.c
+++ b/libraries/ms-drivers/test/test_bts7200_load_switch.c
@@ -132,7 +132,7 @@ void test_bts7200_current_sense_timer_stm32_works(void) {
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 
   // make sure that stop actually stops it
   delay_us(2 * interval_us);
@@ -180,7 +180,7 @@ void test_bts7200_current_sense_timer_pca9539r_works(void) {
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 
   // make sure that stop actually stops it
   delay_us(2 * interval_us);
@@ -221,7 +221,7 @@ void test_bts7200_current_sense_restart(void) {
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 
   // make sure it's stopped
   delay_us(2 * interval_us);
@@ -239,7 +239,7 @@ void test_bts7200_current_sense_restart(void) {
 
   TEST_ASSERT_EQUAL(4, s_times_callback_called);
 
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 
   // make sure it's stopped
   delay_us(2 * interval_us);
@@ -352,7 +352,7 @@ void test_bts7200_current_sense_null_callback(void) {
 
   TEST_ASSERT_OK(bts7200_init_stm32(&s_storage, &settings));
   TEST_ASSERT_OK(bts7200_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Test that bts7200_get_measurement returns ok.
@@ -411,34 +411,6 @@ void test_bts7200_current_sense_get_measurement_pca9539r_valid(void) {
   LOG_DEBUG("PCA9539R readings: %d, %d\n", reading0, reading1);
 }
 
-// Test that bts7200_stop returns true only when it stops a timer
-void test_bts7200_current_sense_stop_return_behaviour(void) {
-  // these don't matter (adc isn't reading anything) but can't be null
-  GpioAddress test_select_pin = { .port = GPIO_PORT_A, .pin = 0 };
-  GpioAddress test_sense_pin = { .port = GPIO_PORT_A, .pin = 0 };
-  // EN0 and EN1 pins
-  GpioAddress test_enable_0_pin = { .port = GPIO_PORT_A, .pin = 1 };
-  GpioAddress test_enable_1_pin = { .port = GPIO_PORT_A, .pin = 2 };
-  uint32_t interval_us = 500;  // 0.5 ms
-  Bts7200Stm32Settings settings = {
-    .select_pin = &test_select_pin,
-    .sense_pin = &test_sense_pin,
-    .enable_0_pin = &test_enable_0_pin,
-    .enable_1_pin = &test_enable_1_pin,
-    .interval_us = interval_us,
-    .resistor = BTS7200_TEST_RESISTOR,
-    .min_fault_voltage_mv = ADC_MIN_FAULT_VOLTAGE,
-    .max_fault_voltage_mv = ADC_MAX_FAULT_VOLTAGE,
-    .callback = &prv_callback_increment,
-  };
-
-  TEST_ASSERT_OK(bts7200_init_stm32(&s_storage, &settings));
-  TEST_ASSERT_FALSE(bts7200_stop(&s_storage));
-  TEST_ASSERT_OK(bts7200_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
-  TEST_ASSERT_FALSE(bts7200_stop(&s_storage));
-}
-
 // Test that the context is actually passed to the function
 void test_bts7200_current_sense_context_passed(void) {
   // these don't matter (adc isn't reading anything) but can't be null
@@ -464,7 +436,7 @@ void test_bts7200_current_sense_context_passed(void) {
 
   TEST_ASSERT_OK(bts7200_init_stm32(&s_storage, &settings));
   TEST_ASSERT_OK(bts7200_start(&s_storage));
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
   TEST_ASSERT_EQUAL(context_pointer, s_received_context);
 }
 
@@ -518,7 +490,7 @@ void test_bts7200_output_0_functions_work(void) {
   TEST_ASSERT_FALSE(bts7200_get_output_0_enabled(&s_storage));
 
   // Stop
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Same as previous test, but with IN1 pin
@@ -572,7 +544,7 @@ void test_bts7200_output_1_functions_work(void) {
   TEST_ASSERT_FALSE(bts7200_get_output_1_enabled(&s_storage));
 
   // Stop
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Test that fault callback called when voltage within fault range.
@@ -643,8 +615,6 @@ void test_bts7200_no_fault_outside_of_fault_range(void) {
   bts7200_get_measurement(&s_storage, &meas0, &meas1);
 
   TEST_ASSERT_EQUAL(0, s_times_fault_callback_called);
-
-  s_times_fault_callback_called = 0;
 }
 
 // Test that the fault callback gets called when running bts7200_start, and
@@ -679,8 +649,7 @@ void test_bts7200_fault_cb_called_from_start(void) {
   s_adc_measurement_1 = ADC_FAULT_VOLTAGE;
   delay_us(2 * interval_us);  // wait for 2* interval
   TEST_ASSERT_TRUE(s_times_fault_callback_called > 0);
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
-  s_times_fault_callback_called = 0;
+  bts7200_stop(&s_storage);
 }
 
 // Test that fault cleared correctly, and that the correct IN pin(s) are toggled
@@ -739,7 +708,7 @@ void test_bts7200_handle_fault_clears_fault(void) {
   TEST_ASSERT_TRUE(bts7200_get_output_0_enabled(&s_storage));
   TEST_ASSERT_TRUE(bts7200_get_output_1_enabled(&s_storage));
 
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Test that fault context is passed on correctly on fault.
@@ -834,7 +803,7 @@ void test_bts7200_enable_fails_during_fault(void) {
   TEST_ASSERT_TRUE(bts7200_get_output_1_enabled(&s_storage));
 
   // Stop
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Test handling of a fault on only one input.
@@ -893,7 +862,7 @@ void test_bts7200_single_input_faults(void) {
   TEST_ASSERT_TRUE(bts7200_get_output_0_enabled(&s_storage));
   TEST_ASSERT_TRUE(bts7200_get_output_1_enabled(&s_storage));
 
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 }
 
 // Make sure that bts7200_stop stops all soft timers and sets
@@ -936,7 +905,7 @@ void test_bts7200_stop_works(void) {
   TEST_ASSERT_TRUE(soft_timer_remaining_time(s_storage.enable_pin_1.fault_timer_id) > 0);
 
   // Stop
-  TEST_ASSERT_TRUE(bts7200_stop(&s_storage));
+  bts7200_stop(&s_storage);
 
   // Verify
   TEST_ASSERT_EQUAL(SOFT_TIMER_INVALID_TIMER, s_storage.measurement_timer_id);


### PR DESCRIPTION
It appears that there's a small chance that bts7200_stop and bts7040_stop will return false even if the measurement timer is active when they're called.  This has caused Travis CI to unexpectedly fail a few times.

Since we don't use the return value of these functions anywhere in the codebase, and it doesn't seem likely that we will in future, this changes them to void functions to avoid any issues with this, and changes the test sequence correspondingly so we (hopefully) don't have random failures anymore.