### PR TITLE
[SOFT-306] Babydriver: minor adc_read compatibility fixes

### DIFF
--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -11,6 +11,9 @@
 
 #define ADC_MOCK_READING 999
 
+// the stm32f0xx's ADC is 12 bits, so the maximum uint16 value is way out of its range
+#define ADC_INVALID_READING ((1 << 16) - 1)
+
 static volatile uint8_t s_callback_runs;
 static volatile bool s_callback_ran;
 

--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -11,9 +11,6 @@
 
 #define ADC_MOCK_READING 999
 
-// the stm32f0xx's ADC is 12 bits, so the maximum uint16 value is way out of its range
-#define ADC_INVALID_READING ((1 << 16) - 1)
-
 static volatile uint8_t s_callback_runs;
 static volatile bool s_callback_ran;
 

--- a/projects/baby_driver/inc/adc_read.h
+++ b/projects/baby_driver/inc/adc_read.h
@@ -3,7 +3,7 @@
 // This module provides the function adc_read_init() which can be used to listen for
 // adc_read_command CAN messages from the babydriver. Once the message is received, the
 // ADC reading from the specificed port and pin is sent back to Python using a CAN message.
-// Requires dispatcher, interrupts, gpio, the event queue, and CAN to be initialized.
+// Requires dispatcher, interrupts, gpio, the event queue, ADC, and CAN to be initialized.
 
 #include "status.h"
 

--- a/projects/baby_driver/scripts/adc_read.py
+++ b/projects/baby_driver/scripts/adc_read.py
@@ -7,7 +7,7 @@ from message_defs import BabydriverMessageId
 NUM_PINS_PER_PORT = 16
 OK_STATUS = 0
 
-def adc_read(port, pin, raw):
+def adc_read(port, pin, raw=False):
     """
     Reads a raw or converted ADC value.
 
@@ -15,6 +15,7 @@ def adc_read(port, pin, raw):
         port: The port of the GPIO pin to read from.
         pin: The pin number of the GPIO pin to read from.
         raw: If raw is True, a raw read should be performed; otherwise a converted read.
+            Defaults to converted.
 
     Returns:
         The ADC reading as a 16-bit integer.
@@ -43,10 +44,10 @@ def adc_read(port, pin, raw):
         (raw, 1),
     ]
     data = can_util.can_pack(data)
-    can_util.send_message(data)
+    can_util.send_message(babydriver_id=BabydriverMessageId.ADC_READ_COMMAND, data=data)
 
     # Wait to receive the first CAN message with data
-    data_msg = can_util.next_message(babydriver_id=BabydriverMessageId.ADC_READ_COMMAND)
+    data_msg = can_util.next_message(babydriver_id=BabydriverMessageId.ADC_READ_DATA)
 
     # Extract the low and high bytes of the ADC conversion
     result_low = data_msg.data[1]

--- a/projects/baby_driver/src/dispatcher.c
+++ b/projects/baby_driver/src/dispatcher.c
@@ -13,9 +13,11 @@ static void *s_context_map[NUM_BABYDRIVER_MESSAGES] = { NULL };
 
 static void prv_call_callback(BabydriverMessageId id, uint8_t data[8]) {
   bool tx_result = true;
-  StatusCode status = s_callback_map[id](data, s_context_map[id], &tx_result);
-  if (tx_result) {
-    CAN_TRANSMIT_BABYDRIVER(BABYDRIVER_MESSAGE_STATUS, status, 0, 0, 0, 0, 0, 0);
+  if (s_callback_map[id] != NULL) {
+    StatusCode status = s_callback_map[id](data, s_context_map[id], &tx_result);
+    if (tx_result) {
+      CAN_TRANSMIT_BABYDRIVER(BABYDRIVER_MESSAGE_STATUS, status, 0, 0, 0, 0, 0, 0);
+    }
   }
 }
 

--- a/projects/baby_driver/src/main.c
+++ b/projects/baby_driver/src/main.c
@@ -8,6 +8,7 @@
 // To send a CAN message from Python write
 // can_util.send_message(<id>, <data>) to send can message
 
+#include "adc.h"
 #include "adc_read.h"
 #include "can.h"
 #include "can_msg_defs.h"
@@ -44,6 +45,7 @@ int main() {
   gpio_init();
   event_queue_init();
   interrupt_init();
+  adc_init(ADC_MODE_SINGLE);
 
   can_init(&s_can_storage, &s_can_settings);
 


### PR DESCRIPTION
Bugfixes:
* `adc` wasn't initialized in firmware, causing weird readings
* fixed a couple mixups in message IDs in Python, now C and Python are compatible
* added a guard in dispatcher to avoid possible segfaults when a babydriver message is received which doesn't have a callback registered

Quality of life improvement: in the Python `adc_read` function, `raw` now defaults to False, meaning a converted read is the default.