### PR TITLE
[SOFT-419] Enable parameterized tests

### DIFF
--- a/libraries/libcore/inc/test_helpers.h
+++ b/libraries/libcore/inc/test_helpers.h
@@ -11,3 +11,6 @@
 
 // Mocking
 #define TEST_MOCK(func) __attribute__((used)) __wrap_##func
+
+// Parameterized tests, see test_parameterized.c for usage examples
+#define TEST_CASE(...)

--- a/libraries/libcore/test/test_parameterized.c
+++ b/libraries/libcore/test/test_parameterized.c
@@ -1,0 +1,17 @@
+#include "log.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+// Example of parameterized tests - use TEST_CASE with arguments to be passed literally to the
+// test function.
+
+void setup_test(void) {}
+void teardown_test(void) {}
+
+TEST_CASE(1, 2)
+TEST_CASE(5, 10)
+TEST_CASE(15, 30)
+void test_parameterized_ints(uint8_t a, uint8_t b) {
+  LOG_DEBUG("a=%d, b=%d\n", a, b);
+  TEST_ASSERT_EQUAL(b, 2 * a);
+}

--- a/libraries/libcore/test/test_parameterized.c
+++ b/libraries/libcore/test/test_parameterized.c
@@ -3,7 +3,7 @@
 #include "unity.h"
 
 // Example of parameterized tests - use TEST_CASE with arguments to be passed literally to the
-// test function.
+// test function. See https://uwmidsun.atlassian.net/l/c/1yZudbzD.
 
 void setup_test(void) {}
 void teardown_test(void) {}

--- a/libraries/unity/auto/generate_test_runner.rb
+++ b/libraries/unity/auto/generate_test_runner.rb
@@ -343,7 +343,7 @@ class UnityTestRunnerGenerator
     if (@options[:use_param_tests])
       tests.each do |test|
         if ((test[:args].nil?) or (test[:args].empty?))
-          output.puts("  RUN_TEST(#{test[:test]}, #{test[:line_number]}, RUN_TEST_NO_ARGS);")
+          output.puts("  RUN_TEST(#{test[:test]}, #{test[:line_number]});")
         else
           test[:args].each {|args| output.puts("  RUN_TEST(#{test[:test]}, #{test[:line_number]}, #{args});")}
         end

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -1,7 +1,8 @@
 # Unity
 UNITY_ROOT := $(LIB_DIR)/unity
 UNITY_SCRIPT_DIR := $(UNITY_ROOT)/auto
-UNITY_GEN_RUNNER := ruby $(UNITY_SCRIPT_DIR)/generate_test_runner.rb --setup_name=setup_test --teardown_name=teardown_test
+UNITY_GEN_RUNNER_FLAGS := --setup_name=setup_test --teardown_name=teardown_test --use_param_tests=1
+UNITY_GEN_RUNNER := ruby $(UNITY_SCRIPT_DIR)/generate_test_runner.rb $(UNITY_GEN_RUNNER_FLAGS)
 
 # Test directories
 $(T)_GEN_DIR := $(BUILD_DIR)/gen/$(PLATFORM)/$(T)


### PR DESCRIPTION
Our testing framework Unity gives us a way to use parameterized tests! See test_parameterized.c for an example. (Apparently it breaks github syntax highlighting though, oh well.)

Highlights:
* `TEST_CASE` macro required for it to work defined in test_helpers.h
* parameterized tests enabled with a flag to the test runner generator script in the makefile
* example in test_parameterized.c
* monkey patch to the test runner generator script to remove `(RUN_TEST_NO_ARGS)` spam in the test logs