### PR TITLE
.project (auto-generated Eclipse IDE file) added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ libraries/version/inc/git_version_impl.h.tmp
 .vs/
 build/
 *.DS_Store
+.project
 
 # Vim
 tags


### PR DESCRIPTION
.project is an auto-generated file for project descriptions