### PR TITLE
SOFT 422: Fix status_ok_or_return to only evaluate argument once

### DIFF
--- a/libraries/libcore/inc/status.h
+++ b/libraries/libcore/inc/status.h
@@ -84,6 +84,6 @@ void status_register_callback(StatusCallback callback);
 // Use to forward failures or continue on success.
 #define status_ok_or_return(code)          \
   ({                                       \
-    __typeof__(code) status_expr = code;   \
-    if (status_expr) return (status_expr); \
+    __typeof__(code) status_expr = (code); \
+    if (status_expr) return status_expr;   \
   })

--- a/libraries/libcore/inc/status.h
+++ b/libraries/libcore/inc/status.h
@@ -82,5 +82,8 @@ void status_register_callback(StatusCallback callback);
 #define status_clear() status_msg(STATUS_CODE_OK, "Clear")
 
 // Use to forward failures or continue on success.
-#define status_ok_or_return(code) \
-  if (code) return (code)
+#define status_ok_or_return(code)          \
+  ({                                       \
+    __typeof__(code) status_expr = code;   \
+    if (status_expr) return (status_expr); \
+  })

--- a/libraries/libcore/test/test_status.c
+++ b/libraries/libcore/test/test_status.c
@@ -59,13 +59,29 @@ static StatusCode prv_ok_or_return() {
   return status_code(STATUS_CODE_UNKNOWN);
 }
 
+// Increments an external count to check how many times the function is called
+static StatusCode prv_status_num_calls(int *count) {
+  (*count)++;
+  return STATUS_CODE_OK;
+}
+
+static StatusCode prv_ok_or_return_function_count(int *count) {
+  status_ok_or_return(prv_status_num_calls(count));
+  return STATUS_CODE_OK;
+}
+
 // Tests the ok_or_return macro
 void test_status_ok_or_return(void) {
+  // Track the number of calls the test funciton makes
+  int numCalls = 0;
   StatusCode ok = prv_ok_or_return();
   Status status = status_get();
   TEST_ASSERT_EQUAL(STATUS_CODE_TIMEOUT, status.code);
   TEST_ASSERT_EQUAL_STRING("prv_ok_or_return", status.caller);
   TEST_ASSERT_EQUAL_STRING("This should work.", status.message);
+  // Checks that the function passed in to the macro is only called once
+  prv_ok_or_return_function_count(&numCalls);
+  TEST_ASSERT_EQUAL(1, numCalls);
 }
 
 void test_status_clear(void) {

--- a/libraries/libcore/test/test_status.c
+++ b/libraries/libcore/test/test_status.c
@@ -73,15 +73,15 @@ static StatusCode prv_ok_or_return_function_count(int *count) {
 // Tests the ok_or_return macro
 void test_status_ok_or_return(void) {
   // Track the number of calls the test funciton makes
-  int numCalls = 0;
+  int num_calls = 0;
   StatusCode ok = prv_ok_or_return();
   Status status = status_get();
   TEST_ASSERT_EQUAL(STATUS_CODE_TIMEOUT, status.code);
   TEST_ASSERT_EQUAL_STRING("prv_ok_or_return", status.caller);
   TEST_ASSERT_EQUAL_STRING("This should work.", status.message);
   // Checks that the function passed in to the macro is only called once
-  prv_ok_or_return_function_count(&numCalls);
-  TEST_ASSERT_EQUAL(1, numCalls);
+  prv_ok_or_return_function_count(&num_calls);
+  TEST_ASSERT_EQUAL(1, num_calls);
 }
 
 void test_status_clear(void) {

--- a/libraries/libcore/test/test_status.c
+++ b/libraries/libcore/test/test_status.c
@@ -60,12 +60,12 @@ static StatusCode prv_ok_or_return() {
 }
 
 // Increments an external count to check how many times the function is called
-static StatusCode prv_status_num_calls(int *count) {
+static StatusCode prv_status_num_calls(uint16_t *count) {
   (*count)++;
   return STATUS_CODE_OK;
 }
 
-static StatusCode prv_ok_or_return_function_count(int *count) {
+static StatusCode prv_ok_or_return_function_count(uint16_t *count) {
   status_ok_or_return(prv_status_num_calls(count));
   return STATUS_CODE_OK;
 }

--- a/libraries/libcore/test/test_status.c
+++ b/libraries/libcore/test/test_status.c
@@ -72,8 +72,8 @@ static StatusCode prv_ok_or_return_function_count(int *count) {
 
 // Tests the ok_or_return macro
 void test_status_ok_or_return(void) {
-  // Track the number of calls the test funciton makes
-  int num_calls = 0;
+  // Track the number of calls the test function makes
+  uint16_t num_calls = 0;
   StatusCode ok = prv_ok_or_return();
   Status status = status_get();
   TEST_ASSERT_EQUAL(STATUS_CODE_TIMEOUT, status.code);

--- a/libraries/libcore/test/test_status.c
+++ b/libraries/libcore/test/test_status.c
@@ -62,7 +62,8 @@ static StatusCode prv_ok_or_return() {
 // Increments an external count to check how many times the function is called
 static StatusCode prv_status_num_calls(uint16_t *count) {
   (*count)++;
-  return STATUS_CODE_OK;
+  // Returning an error to check that the function isn't being called twice on failure
+  return STATUS_CODE_INTERNAL_ERROR;
 }
 
 static StatusCode prv_ok_or_return_function_count(uint16_t *count) {


### PR DESCRIPTION
See Ticket: https://uwmidsun.atlassian.net/browse/SOFT-422

Implemented statement expression to set function return to a variable, and return that variable if not equal to `STATUS_CODE_OK` (0).

A test has been added as well.