### PR TITLE
[SOFT-440] Fix watchdog cancelling random soft timers

### DIFF
--- a/libraries/ms-common/src/watchdog.c
+++ b/libraries/ms-common/src/watchdog.c
@@ -10,6 +10,7 @@ void watchdog_start(WatchdogStorage *storage, WatchdogTimeout timeout_ms,
   storage->timeout_ms = timeout_ms;
   storage->callback = callback;
   storage->callback_context = context;
+  storage->timer_id = SOFT_TIMER_INVALID_TIMER;
   watchdog_kick(storage);
 }
 

--- a/libraries/ms-common/test/test_watchdog.c
+++ b/libraries/ms-common/test/test_watchdog.c
@@ -23,20 +23,20 @@ const WatchdogSettings settings = {
   .callback = prv_expiry_callback,
 };
 
-static void prv_reset_callback() {
+static void prv_reset_callback(void) {
   s_expiry_called = false;
   s_passed_context = (void *)0;
 }
 
-void setup_test() {
+void setup_test(void) {
   interrupt_init();
   soft_timer_init();
   prv_reset_callback();
 }
 
-void teardown_test() {}
+void teardown_test(void) {}
 
-void test_watchdog_expiry() {
+void test_watchdog_expiry(void) {
   uint32_t context_data = 0xdeadbeef;
   watchdog_start(&s_watchdog, TIMEOUT_MS, prv_expiry_callback, &context_data);
   TEST_ASSERT_FALSE(s_expiry_called);
@@ -47,7 +47,7 @@ void test_watchdog_expiry() {
   TEST_ASSERT_EQUAL(&context_data, s_passed_context);
 }
 
-void test_watchdog_kick() {
+void test_watchdog_kick(void) {
   uint32_t context_data = 0xdeadbeef;
   watchdog_start(&s_watchdog, TIMEOUT_MS, prv_expiry_callback, &context_data);
 
@@ -63,7 +63,7 @@ void test_watchdog_kick() {
   TEST_ASSERT_EQUAL(&context_data, s_passed_context);
 }
 
-void test_watchdog_expired_does_not_call_callback_multiple_times() {
+void test_watchdog_expired_does_not_call_callback_multiple_times(void) {
   uint32_t context_data = 0xdeadbeef;
   watchdog_start(&s_watchdog, TIMEOUT_MS, prv_expiry_callback, &context_data);
 
@@ -77,7 +77,7 @@ void test_watchdog_expired_does_not_call_callback_multiple_times() {
   TEST_ASSERT_FALSE(s_expiry_called);
 }
 
-void test_watchdog_expired_can_start_again() {
+void test_watchdog_expired_can_start_again(void) {
   uint32_t context_data = 0xdeadbeef;
   watchdog_start(&s_watchdog, TIMEOUT_MS, prv_expiry_callback, &context_data);
 


### PR DESCRIPTION
The `watchdog` library wasn't setting the `timer_id` to `SOFT_TIMER_INVALID_TIMER` before calling `watchdog_kick` which cancels the timer with id `timer_id`, so if we're unlucky, the default `timer_id` would be a valid timer id used by some other soft timer which would get cancelled, causing *super* hard to debug issues. This appeared when trying to debug babydriver.

Fixed by setting the timer ID in `watchdog_start`. Also changed all the empty parameter lists in test_watchdog.c to `(void)` instead of `()` to comply with conventions.