### PR TITLE
[SOFT-447] Patch x86 CAN library to allow a message with a zero CAN ID

### DIFF
--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -89,7 +89,7 @@ static void *prv_rx_thread(void *arg) {
     if (FD_ISSET(s_socket_data.can_fd, &input_fds)) {
       int bytes =
           read(s_socket_data.can_fd, &s_socket_data.rx_frame, sizeof(s_socket_data.rx_frame));
-      s_socket_data.rx_frame_valid = true;
+      s_socket_data.rx_frame_valid = (bytes != -1);
 
       if (s_socket_data.handlers[CAN_HW_EVENT_MSG_RX].callback != NULL) {
         s_socket_data.handlers[CAN_HW_EVENT_MSG_RX].callback(

--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -38,6 +38,7 @@ typedef struct CanHwEventHandler {
 typedef struct CanHwSocketData {
   int can_fd;
   struct can_frame rx_frame;
+  bool rx_frame_valid;
   Fifo tx_fifo;
   struct can_frame tx_frames[CAN_HW_TX_FIFO_LEN];
   struct can_filter filters[CAN_HW_MAX_FILTERS];
@@ -88,6 +89,7 @@ static void *prv_rx_thread(void *arg) {
     if (FD_ISSET(s_socket_data.can_fd, &input_fds)) {
       int bytes =
           read(s_socket_data.can_fd, &s_socket_data.rx_frame, sizeof(s_socket_data.rx_frame));
+      s_socket_data.rx_frame_valid = true;
 
       if (s_socket_data.handlers[CAN_HW_EVENT_MSG_RX].callback != NULL) {
         s_socket_data.handlers[CAN_HW_EVENT_MSG_RX].callback(
@@ -266,8 +268,7 @@ StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size
 
 // Must be called within the RX handler, returns whether a message was processed
 bool can_hw_receive(uint32_t *id, bool *extended, uint64_t *data, size_t *len) {
-  if (s_socket_data.rx_frame.can_id == 0) {
-    // Assumes that we'll never transmit something with a CAN ID of all 0s
+  if (!s_socket_data.rx_frame_valid) {
     return false;
   }
 
@@ -278,5 +279,6 @@ bool can_hw_receive(uint32_t *id, bool *extended, uint64_t *data, size_t *len) {
   *len = s_socket_data.rx_frame.can_dlc;
 
   memset(&s_socket_data.rx_frame, 0, sizeof(s_socket_data.rx_frame));
+  s_socket_data.rx_frame_valid = false;
   return true;
 }

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -48,6 +48,7 @@ static StatusCode prv_ack_callback_status(CanMessageId msg_id, uint16_t device, 
 }
 
 static void prv_clock_tx(void) {
+  LOG_DEBUG("prv_clock_tx called\n");
   Event e = { 0 };
   StatusCode ret = event_process(&e);
   TEST_ASSERT_OK(ret);

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -48,7 +48,6 @@ static StatusCode prv_ack_callback_status(CanMessageId msg_id, uint16_t device, 
 }
 
 static void prv_clock_tx(void) {
-  LOG_DEBUG("prv_clock_tx called\n");
   Event e = { 0 };
   StatusCode ret = event_process(&e);
   TEST_ASSERT_OK(ret);


### PR DESCRIPTION
On x86, the flow for receiving a CAN message is the following:
1. The RX thread (`prv_rx_thread` in can_hw.c) reads a CAN frame from the socket.
2. The RX thread calls a handler, which turns out to be `prv_rx_handler` in can.c.
3. `prv_rx_handler` calls `can_hw_receive` until it returns false. On x86, `can_hw_receive` will only rx one message (the most recently rx'd one), but it does this to support STM32 which can receive multiple in a row.
4. On the first call, `can_hw_receive` sees that it has a valid frame received, passes the data upwards, resets it, and returns true; on the second call, it sees that it doesn't have a valid frame and returns false.

Previously, we determined whether the frame was valid by assuming that a CAN arbitration ID of 0 would never happen, so the zero ID caused by memsetting the frame to 0 was checked. Now with the bootloader, an ID of 0 is possible (and likely), so we use a separate flag to determine if the frame is valid.

I don't *think* there are any race conditions caused by this change but @Max-MZ @jessm I'd appreciate other eyes as well. I have checked that babydriver `spi_exchange([1]*255, 255)` (exchanging >60 messages) works with this change, and also verified with `cansend` that this lets an ID 0 message get processed.