### PR TITLE
Soft 345 unify mpxe pipes

### DIFF
--- a/libraries/libcore/inc/log.h
+++ b/libraries/libcore/inc/log.h
@@ -31,24 +31,22 @@ typedef enum {
     }                                                                         \
   } while (0)
 #else
-#include <pthread.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "store.h"
 
-extern bool store_lib_inited;
+#define MAX_LOG_LEN 256
+static char s_log_buf[MAX_LOG_LEN];
 
 // fflush necessary for printing through pipes
-#define LOG(level, fmt, ...)                                                  \
-  do {                                                                        \
-    if ((level) >= LOG_LEVEL_VERBOSITY) {                                     \
-      log_mutex_lock();                                                       \
-      printf("[%u] %s:%u: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
-      fflush(stdout);                                                         \
-      if (store_lib_inited) {                                                 \
-        log_mutex_lock();                                                     \
-      }                                                                       \
-      log_mutex_unlock();                                                     \
-    }                                                                         \
+#define LOG(level, fmt, ...)                                                                  \
+  do {                                                                                        \
+    if ((level) >= LOG_LEVEL_VERBOSITY) {                                                     \
+      memset(s_log_buf, 0, sizeof(s_log_buf));                                                \
+      int len = snprintf(s_log_buf, sizeof(s_log_buf), "[%u] %s:%u: " fmt, (level), __FILE__, \
+                         __LINE__, ##__VA_ARGS__);                                            \
+      log_export(s_log_buf, len);                                                             \
+    }                                                                                         \
   } while (0)
 #endif

--- a/libraries/mpxe-store/inc/store.h
+++ b/libraries/mpxe-store/inc/store.h
@@ -41,6 +41,5 @@ void *store_get(MxStoreType type, void *key);
 // Call at every store update to export store to parent.
 void store_export(MxStoreType type, void *store, void *key);
 
-// Locking for logs
-void log_mutex_lock();
-void log_mutex_unlock();
+// Logging also happens via store, but it's a special case
+void log_export(char *buf, uint16_t len);

--- a/mpxe/harness/project.py
+++ b/mpxe/harness/project.py
@@ -60,9 +60,11 @@ class Project:
 
     def handle_store(self, pm, msg):
         store_info = decoder.decode_store_info(msg)
-        key = (store_info.type, store_info.key)
-        self.stores[key] = decoder.decode_store(store_info)
-        self.sim.handle_update(pm, self)
-
-    def handle_log(self, pm, log):
-        self.sim.handle_log(pm, self, log)
+        if store_info.type == stores_pb2.LOG:
+            mxlog = stores_pb2.MxLog()
+            mxlog.ParseFromString(store_info.msg)
+            self.sim.handle_log(pm, self, mxlog.log.decode('utf-8').rstrip())
+        else:
+            key = (store_info.type, store_info.key)
+            self.stores[key] = decoder.decode_store(store_info)
+            self.sim.handle_update(pm, self)

--- a/mpxe/protos/stores.proto
+++ b/mpxe/protos/stores.proto
@@ -1,15 +1,20 @@
 syntax = "proto3";
 
 enum MxStoreType {
-  GPIO = 0;
-  ADS1015 = 1;
-  MCP2515 = 2;
-  ADS1259 = 3;
-  ADT7476A = 4;
-  ADC = 5;
-  PCA9539R = 6;
-  MCP23008 = 7;
-  END = 8;
+  LOG = 0;
+  GPIO = 1;
+  ADS1015 = 2;
+  MCP2515 = 3;
+  ADS1259 = 4;
+  ADT7476A = 5;
+  ADC = 6;
+  PCA9539R = 7;
+  MCP23008 = 8;
+  END = 9;
+}
+
+message MxLog {
+  bytes log = 1;
 }
 
 message MxStoreInfo {


### PR DESCRIPTION
This had to happen eventually.

### Intent
Rather than have one pipe for log output and one pipe for protobuf output, I want to unify these into a single pipe and wrap everything in a wrapper message. The naming is currently a bit off (since everything gets exported in a `MxStoreInfo`), but this makes it easier to extend the IO to C: add a new message type, then have separate handling logic for that message type.

Although this is a general improvement, it was originally intended to simplify the implementation of startup conditions.

### Implementation
#### Logging
In log.h, rather than printing and flushing stdout, we print to a buffer, then call some custom logic in store.c to package it into an `MxStoreInfo` and export it via the normal `store_export` logic. We now set a buffer size of 256 characters for logging, but terminals are only ~90 characters wide anyways, so 256 should be plenty. Logs will be silently truncated above this, but I think that's fine.
#### Store library
Logging happens more or less through the regular store export flow, but I didn't want to set up extra files for it, so I threw the logic in store.c. I removed everything that touched the `ctop_fifo` (including the log lock), and changed it so stores are written directly to stdout. Finally, I register the regular store funcs for the `LOG` type, but without unnecessary ones.
#### Harness
Similar to the store library changes, I removed all `ctop_fifo` stuff, and shortcutted the polling to handle logs if the store info type is a log. I made the log type 0 because it's a unique type.

### Testing
Ran `make mpxe`, seemed to work fine.

### Future work
We could potentially split all messages passed between python and C into the categories of "meta" (logging, commands for synchronization, etc.) and "data" (stores). I think this dichotomy should cover everything we need, and makes it clean to add extra command types or other messages.
