### PR TITLE
added a timeout of 12 minutes on main.yml file for github wokflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-16.04
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
Since there is only one job, I thought a default timeout of 12 minutes would be good enough.