### PR TITLE
[SOFT-233] Always return OK from retrying to avoid leftover acks

### DIFF
--- a/libraries/ms-helper/inc/can_tx_retry_wrapper.h
+++ b/libraries/ms-helper/inc/can_tx_retry_wrapper.h
@@ -6,6 +6,11 @@
 // the acknowledgement request. If retry_indefinitely is set, the module keeps
 // retrying that message.
 
+// Despite the ack_bitset field, this module only supports messages that require
+// a single ack. This is to avoid a distributed consensus problem where some
+// devices successfully ack and some don't, potentially causing unintended
+// side effects upon retrying message broadcast.
+
 // Requires CAN, GPIO, soft timers, event queue, and interrupts to be initialized.
 
 #include "can_ack.h"

--- a/libraries/ms-helper/src/can_tx_retry_wrapper.c
+++ b/libraries/ms-helper/src/can_tx_retry_wrapper.c
@@ -24,7 +24,7 @@ static StatusCode prv_can_simple_ack(CanMessageId msg_id, uint16_t device, CanAc
       event_raise(storage->retry_request.fault_event_id, storage->retry_request.fault_event_data);
       if (!storage->retry_request.retry_indefinitely) {
         storage->retry_count = 0;
-        return STATUS_CODE_RESOURCE_EXHAUSTED;
+        return STATUS_CODE_OK;
       }
     }
     if (storage->retry_count < storage->retries || storage->retry_request.retry_indefinitely) {


### PR DESCRIPTION
The module `can_tx_retry_wrapper` is inherently broken for (at least) two reasons:
1. Upon receiving the maximum number of failures it resets its internal statistics (i.e. retry count), but leaves the ghost ack live in the queue to time out later. At best this is a gracefully handled unpleasant surprise, but at worst this re-triggers the retry logic and broadcasts unwanted messages.
2. If anyone were to employ this with an `ack_bitset` of more than one device, an ack from one device would leave `num_remaining` non-zero and cause a retry to all devices, potentially causing difficult side effects

This PR solves both these issues by:
1. Cancelling the ack no matter what the status was after the maximum number of errors are received
2. Properly warning module users of its limitations with an informative comment

This hopefully reduces some of the flakiness in dependent tests (test_relay_tx.c).