### PR TITLE
[SOFT-233] Unflake CAN and some tests

### DIFF
--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -112,9 +112,10 @@ void test_can_basic(void) {
 void test_can_filter(void) {
   volatile CanMessage rx_msg = { 0 };
   can_add_filter(0x2);
+  can_add_filter(0x3);
 
   can_register_rx_handler(0x1, prv_rx_callback, &rx_msg);
-  can_register_rx_handler(0x2, prv_rx_callback, &rx_msg);
+  can_register_rx_handler(0x3, prv_rx_callback, &rx_msg);
 
   CanMessage msg = {
     .msg_id = 0x1,               //
@@ -127,7 +128,7 @@ void test_can_filter(void) {
   TEST_ASSERT_OK(ret);
   prv_clock_tx();
 
-  msg.msg_id = 0x2;
+  msg.msg_id = 0x3;
   ret = can_transmit(&msg, NULL);
   TEST_ASSERT_OK(ret);
   prv_clock_tx();

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -20,10 +20,8 @@ static void prv_handle_rx(void *context) {
   }
 }
 
-static void prv_wait_rx(size_t wait_for) {
-  size_t expected = s_msg_rx + wait_for;
-
-  while (s_msg_rx != expected) {
+static void prv_wait_rx(size_t wait_until) {
+  while (s_msg_rx != wait_until) {
   }
 }
 

--- a/projects/baby_driver/test/test_spi_exchange.c
+++ b/projects/baby_driver/test/test_spi_exchange.c
@@ -24,6 +24,10 @@
 
 #define TEST_BAUDRATE (6000000)
 
+#define TEST_SPI_EXCHANGE_DELAY_US 100
+// Timeout is 1000 times longer than delay
+#define TEST_SPI_EXCHANGE_TIMEOUT_MS TEST_SPI_EXCHANGE_DELAY_US
+
 typedef enum {
   TEST_CAN_EVENT_TX = 0,
   TEST_CAN_EVENT_RX,
@@ -56,6 +60,22 @@ static SpiSettings s_spi_settings_test_2 = { .baudrate = 6000000,
                                              .sclk = CONTROLLER_BOARD_ADDR_SPI2_SCK,
                                              .cs = CONTROLLER_BOARD_ADDR_SPI2_NSS };
 #define SPI_PORT_TEST_2 (SPI_PORT_2)
+
+static void prv_tx_rx_callback_msgs(uint16_t num_messages) {
+  // The ordering of events from babydriver callbacks is abnormal: CAN_TRANSMIT_BABYDRIVER
+  // is called in a rapidly firing callback, without event processing in between. So, we
+  // delay to let the callbacks fire, then process all TX events at once then all RX events
+  // at once.
+
+  // The +1 is to account for the initial delay before the module starts TXing
+  delay_us((uint32_t)(TEST_SPI_EXCHANGE_DELAY_US * (num_messages + 1)));
+  for (uint16_t i = 0; i < num_messages; i++) {
+    MS_TEST_HELPER_CAN_TX(TEST_CAN_EVENT_TX);
+  }
+  for (uint16_t i = 0; i < num_messages; i++) {
+    MS_TEST_HELPER_CAN_RX(TEST_CAN_EVENT_RX);
+  }
+}
 
 static StatusCode prv_callback_spi_exchange_status(uint8_t data[2], void *context,
                                                    bool *tx_result) {
@@ -165,7 +185,7 @@ void setup_test(void) {
   initialize_can_and_dependencies(&s_can_storage, SYSTEM_CAN_DEVICE_BABYDRIVER, TEST_CAN_EVENT_TX,
                                   TEST_CAN_EVENT_RX, TEST_CAN_EVENT_FAULT);
   TEST_ASSERT_OK(dispatcher_init());
-  TEST_ASSERT_OK(spi_exchange_init(DEFAULT_SPI_EXCHANGE_TIMEOUT_MS, DEFAULT_SPI_EXCHANGE_TX_DELAY));
+  TEST_ASSERT_OK(spi_exchange_init(TEST_SPI_EXCHANGE_TIMEOUT_MS, TEST_SPI_EXCHANGE_DELAY_US));
 
   prv_clear_received_data_array();
   memset(s_received_data_status, 0, sizeof(s_received_data_status));
@@ -189,8 +209,7 @@ void test_valid_input(void) {
   prv_send_meta_data(0, 0, 7, 7, 0, 0, 1, TEST_BAUDRATE);
 
   prv_send_data(7);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
+  prv_tx_rx_callback_msgs(2);
 
   TEST_ASSERT_EQUAL(8, s_num_bytes);
   prv_test_equal_multiple_messages();
@@ -218,8 +237,8 @@ void test_valid_input(void) {
   prv_send_meta_data(0, 0, 7, 7, 0, 0, 0, TEST_BAUDRATE);
 
   prv_send_data(7);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
+  // wait for expected number of callbacks
+  prv_tx_rx_callback_msgs(2);
 
   TEST_ASSERT_EQUAL(8, s_num_bytes);
   prv_test_equal_multiple_messages();
@@ -255,8 +274,7 @@ void test_valid_input(void) {
   prv_send_meta_data(1, 3, 7, 7, 0, 0, 0, TEST_BAUDRATE);
 
   prv_send_data(7);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
+  prv_tx_rx_callback_msgs(2);
 
   TEST_ASSERT_EQUAL(8, s_num_bytes);
   prv_test_equal_multiple_messages();
@@ -285,9 +303,7 @@ void test_valid_input(void) {
 
   prv_send_data(7);
   prv_send_data(1);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
-  MS_TEST_HELPER_CAN_TX_RX(TEST_CAN_EVENT_TX, TEST_CAN_EVENT_RX);
+  prv_tx_rx_callback_msgs(3);
 
   TEST_ASSERT_EQUAL(10, s_num_bytes);
   prv_test_equal_multiple_messages();

--- a/projects/baby_driver/test/test_spi_exchange.c
+++ b/projects/baby_driver/test/test_spi_exchange.c
@@ -24,10 +24,6 @@
 
 #define TEST_BAUDRATE (6000000)
 
-#define TEST_SPI_EXCHANGE_DELAY_US 100
-// Timeout is 1000 times longer than delay
-#define TEST_SPI_EXCHANGE_TIMEOUT_MS TEST_SPI_EXCHANGE_DELAY_US
-
 typedef enum {
   TEST_CAN_EVENT_TX = 0,
   TEST_CAN_EVENT_RX,
@@ -68,7 +64,7 @@ static void prv_tx_rx_callback_msgs(uint16_t num_messages) {
   // at once.
 
   // The +1 is to account for the initial delay before the module starts TXing
-  delay_us((uint32_t)(TEST_SPI_EXCHANGE_DELAY_US * (num_messages + 1)));
+  delay_us((uint32_t)(DEFAULT_SPI_EXCHANGE_TX_DELAY * (num_messages + 1)));
   for (uint16_t i = 0; i < num_messages; i++) {
     MS_TEST_HELPER_CAN_TX(TEST_CAN_EVENT_TX);
   }
@@ -185,7 +181,7 @@ void setup_test(void) {
   initialize_can_and_dependencies(&s_can_storage, SYSTEM_CAN_DEVICE_BABYDRIVER, TEST_CAN_EVENT_TX,
                                   TEST_CAN_EVENT_RX, TEST_CAN_EVENT_FAULT);
   TEST_ASSERT_OK(dispatcher_init());
-  TEST_ASSERT_OK(spi_exchange_init(TEST_SPI_EXCHANGE_TIMEOUT_MS, TEST_SPI_EXCHANGE_DELAY_US));
+  TEST_ASSERT_OK(spi_exchange_init(DEFAULT_SPI_EXCHANGE_TIMEOUT_MS, DEFAULT_SPI_EXCHANGE_TX_DELAY));
 
   prv_clear_received_data_array();
   memset(s_received_data_status, 0, sizeof(s_received_data_status));


### PR DESCRIPTION
## Why am I doing this
This PR aims to shortcut socketcan when CAN is configured in loopback mode. We want to do this because there's an unfortunately long delay between when a message is TXed and RXed over socketcan, sometimes on the order of hundreds of milliseconds. This issue is exacerbated by the 3 thread model we use for CAN, in which the TX thread can take a while to wake up before TXing a message, leading to an even longer delay.

Some tests rely on CAN delay being deterministic, and occasionally fail when a message takes too long. This causes much grief and hurts developer velocity.

As much as I wanted this to be a clean change in just can_hw.c, some tests relied on CAN taking a non-zero amount of time to process a message. I believe this reliance is incorrect, since it causes non-determinism and doesn't account for what's really going on.

## The play by play
Probably best to be looking at the file I'm talking about at the same time as reading this section.
File by file:
### can_hw.c
If we init can with loopback mode, we don't bother with the threads at all, just copy directly from the TX fifo to the RX frame, and call the TX/RX callbacks sequentially. To account for filters, we apply them manually between TX and RX callbacks to mimic how it'd normally work. We also don't apply the filters to the socket, since we never open the socket and that errors out.

### test_can_hw.c
This test previously relied on CAN to have a delay between sending and receiving a message. Upon calling `can_hw_transmit()` (e.g. on line 59 in `test_can_hw_loop()`), the test would jump to `prv_wait_rx()`, check the number of messages received, then wait until it incremented. With the shortcut, the message would get received immediately after `can_hw_transmit()` was called, meaning the increment happened before we were waiting for it. Instead,  this PR sets a number of messages received to wait for explicitly, rather than an increment.

### test_spi_exchange.c
This test wasn't _that_ flaky, but it became really flaky when I shortened the timing, suggesting investigation was necessary.
This test relied on CAN being slower than a single callback (2 ms), but faster than two callbacks (4 ms). This meant the old flow was:
1. Send data over CAN, and TX/RX it via `MS_TEST_HELPER...`
2. TX, then spin while waiting for RX
3. Repeat for the second callback
You'd think that this process should be fine since now TX/RX should be faster so it should be fine to spin, but my theory is that with a really short delay, the callback would fire twice before a single event was RX/TXed, meaning there would be two TX events in the queue, and `MS_TEST_HELPER_CAN_TX_RX()` would fail. I changed this to delay appropriately for all callbacks to fire, then process all the TX events, then process all the RX events. This adds some determinism and lets us cut down the timings without worrying about <10ms delays messing us up.