### PR TITLE
[SOFT-233] Deterministic soft timers

### DIFF
--- a/libraries/ms-common/test/test_adc.c
+++ b/libraries/ms-common/test/test_adc.c
@@ -6,6 +6,7 @@
 #include "soft_timer.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 // temps in kelvin
 #define ADC_INVALID_UNDER_TEMP 253
@@ -153,6 +154,7 @@ void test_single(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_read_raw(ADC_CHANNEL_3, &reading));
 
   while (!s_callback_ran) {
+    wait();
   }
 
   TEST_ASSERT_TRUE(s_callback_ran);
@@ -175,6 +177,7 @@ void test_continuous() {
 
   // Run a busy loop until a callback is triggered
   while (!s_callback_runs) {
+    wait();
   }
 
   TEST_ASSERT_TRUE(s_callback_ran);
@@ -296,6 +299,7 @@ void test_pin_single(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, adc_read_raw_pin(s_empty_pin, &reading));
 
   while (!s_pin_callback_ran) {
+    wait();
   }
 
   TEST_ASSERT_TRUE(s_pin_callback_ran);
@@ -318,6 +322,7 @@ void test_pin_continuous() {
 
   // Run a busy loop until a callback is triggered
   while (!s_pin_callback_ran) {
+    wait();
   }
 
   TEST_ASSERT_TRUE(s_pin_callback_ran);

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -6,6 +6,7 @@
 #include "log.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 #define TEST_CAN_UNKNOWN_MSG_ID 0xA
 #define TEST_CAN_DEVICE_ID 0x1
@@ -100,6 +101,7 @@ void test_can_basic(void) {
   Event e = { 0 };
   // Wait for RX
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   bool processed = can_process_event(&e);
@@ -135,6 +137,7 @@ void test_can_filter(void) {
 
   Event e = { 0 };
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   TEST_ASSERT_EQUAL(1, e.data);
@@ -173,6 +176,7 @@ void test_can_ack(void) {
   Event e = { 0 };
   // Handle RX of message and attempt transmit of ACK
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   bool processed = can_process_event(&e);
@@ -181,6 +185,7 @@ void test_can_ack(void) {
 
   // Handle RX of ACK
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   processed = can_process_event(&e);
@@ -208,6 +213,7 @@ void test_can_ack_expire(void) {
   TEST_ASSERT_OK(ret);
 
   while (ack_status == NUM_CAN_ACK_STATUSES) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(CAN_ACK_STATUS_TIMEOUT, ack_status);
@@ -238,6 +244,7 @@ void test_can_ack_status(void) {
   Event e = { 0 };
   // Handle RX of message and attempt transmit of ACK
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   bool processed = can_process_event(&e);
@@ -246,6 +253,7 @@ void test_can_ack_status(void) {
 
   // Handle RX of ACK
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   processed = can_process_event(&e);
@@ -272,6 +280,7 @@ void test_can_default(void) {
   Event e = { 0 };
   // Handle message RX
   while (event_process(&e) != STATUS_CODE_OK) {
+    wait();
   }
   TEST_ASSERT_EQUAL(TEST_CAN_EVENT_RX, e.id);
   bool processed = can_process_event(&e);

--- a/libraries/ms-common/test/test_can_ack.c
+++ b/libraries/ms-common/test/test_can_ack.c
@@ -4,6 +4,7 @@
 #include "soft_timer.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 typedef enum {
   TEST_CAN_ACK_DEVICE_A = 0,
@@ -137,6 +138,7 @@ void test_can_ack_expiry(void) {
   can_ack_add_request(&s_ack_requests, 0x2, &ack_request);
 
   while (data.msg_id == 0) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(0x2, data.msg_id);
@@ -168,6 +170,7 @@ void test_can_ack_expiry_moved(void) {
   TEST_ASSERT_EQUAL(1, s_ack_requests.num_requests);
 
   while (data.msg_id == can_msg.msg_id) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(0x2, data.msg_id);

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -6,6 +6,7 @@
 #include "soft_timer.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 static volatile size_t s_msg_rx;
 static volatile uint32_t s_rx_id;
@@ -22,6 +23,7 @@ static void prv_handle_rx(void *context) {
 
 static void prv_wait_rx(size_t wait_until) {
   while (s_msg_rx != wait_until) {
+    wait();
   }
 }
 

--- a/libraries/ms-common/test/test_soft_timer.c
+++ b/libraries/ms-common/test/test_soft_timer.c
@@ -8,6 +8,7 @@
 #include "log.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 static void prv_timeout_cb(SoftTimerId timer_id, void *context) {
   SoftTimerId *cb_id = context;
@@ -38,6 +39,7 @@ void test_soft_timer_basic(void) {
   TEST_ASSERT_TRUE(soft_timer_inuse());
 
   while (cb_id == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id, cb_id);
@@ -81,6 +83,7 @@ void test_soft_timer_preempt(void) {
   TEST_ASSERT_TRUE(soft_timer_inuse());
 
   while (cb_id_short == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_short, cb_id_short);
@@ -89,6 +92,7 @@ void test_soft_timer_preempt(void) {
   TEST_ASSERT_NOT_EQUAL(id_longer, cb_id_longer);
 
   while (cb_id_medium == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_medium, cb_id_medium);
@@ -96,12 +100,14 @@ void test_soft_timer_preempt(void) {
   TEST_ASSERT_NOT_EQUAL(id_longer, cb_id_longer);
 
   while (cb_id_long == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_long, cb_id_long);
   TEST_ASSERT_NOT_EQUAL(id_longer, cb_id_longer);
 
   while (cb_id_longer == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_longer, cb_id_longer);
@@ -130,6 +136,7 @@ void test_soft_timer_cancelled_timer(void) {
   soft_timer_cancel(id_short);
 
   while (cb_id_long == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_long, cb_id_long);
@@ -193,6 +200,7 @@ void test_soft_timer_exhausted(void) {
   TEST_ASSERT_OK(ret);
 
   while (cb_id_single == SOFT_TIMER_INVALID_TIMER) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(id_single, cb_id_single);

--- a/libraries/ms-drivers/test/test_bts7040_load_switch.c
+++ b/libraries/ms-drivers/test/test_bts7040_load_switch.c
@@ -6,6 +6,7 @@
 #include "log.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 #define TEST_I2C_PORT I2C_PORT_2
 #define TEST_I2C_ADDRESS 0x74
@@ -119,6 +120,7 @@ void test_bts7040_current_sense_timer_stm32_works(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -163,6 +165,7 @@ void test_bts7040_current_sense_timer_pca9539r_works(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -201,6 +204,7 @@ void test_bts7040_current_sense_restart(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -219,6 +223,7 @@ void test_bts7040_current_sense_restart(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 3) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(4, s_times_callback_called);

--- a/libraries/ms-drivers/test/test_bts7200_load_switch.c
+++ b/libraries/ms-drivers/test/test_bts7200_load_switch.c
@@ -5,6 +5,7 @@
 #include "log.h"
 #include "test_helpers.h"
 #include "unity.h"
+#include "wait.h"
 
 #define TEST_I2C_PORT I2C_PORT_2
 
@@ -131,6 +132,7 @@ void test_bts7200_current_sense_timer_stm32_works(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -179,6 +181,7 @@ void test_bts7200_current_sense_timer_pca9539r_works(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -221,6 +224,7 @@ void test_bts7200_current_sense_restart(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 1) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(2, s_times_callback_called);
@@ -239,6 +243,7 @@ void test_bts7200_current_sense_restart(void) {
 
   // wait in a busy loop for the callback to be called
   while (s_times_callback_called == 3) {
+    wait();
   }
 
   TEST_ASSERT_EQUAL(4, s_times_callback_called);


### PR DESCRIPTION
For the soft timers, this changes the implementation from array-based individual timers to list-based backed by a single timer, similar to how the stm32 version works.

Some tests still struggled. I found that busy-looping would occasionally miss timer events, but adding a `wait()` seemed to help. This seems worth having regardless of whether it helps consistency or not, so I threw a bunch of waits around.