### PR TITLE
[SOFT-458] Add BUG macro for initialization debuggability

### DIFF
--- a/libraries/libcore/inc/bug.h
+++ b/libraries/libcore/inc/bug.h
@@ -4,7 +4,7 @@
 // returns a non-OK status code.
 //
 // Usage:
-// BUG(my_critical_function_that_can_never_fail());
+// BUG(initialize_my_critical_module());
 //
 // BUG is meant to wrap operations where the only sensible thing to do on failure is to exit with
 // debugging information, such as initializing modules in main. If a BUG is triggered, it should

--- a/libraries/libcore/inc/bug.h
+++ b/libraries/libcore/inc/bug.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "status.h"
+
+#define BUG(call)                                                                    \
+  ({                                                                                 \
+    __typeof__(call) status_code = (call);                                           \
+    if (status_code) {                                                               \
+      Status global_status = status_get();                                           \
+      LOG_CRITICAL(                                                                  \
+          "Bug triggered, aborting!\n"                                               \
+          "This indicates initialization failure or another unrecoverable fault.\n"  \
+          "Call returned status code %d:\n"                                          \
+          "  %s\n"                                                                   \
+          "Location: %s:%d, in %s\n"                                                 \
+          "Info from last time status_code was called (may or may not be useful):\n" \
+          "  Status code: %d\n"                                                      \
+          "  Location: %s, in %s\n"                                                  \
+          "  Message: %s\n",                                                         \
+          status_code, #call, __FILE__, __LINE__, __FUNCTION__, global_status.code,  \
+          global_status.source, global_status.caller, global_status.message);        \
+      __builtin_trap();                                                              \
+    }                                                                                \
+  })

--- a/libraries/libcore/inc/bug.h
+++ b/libraries/libcore/inc/bug.h
@@ -1,24 +1,35 @@
 #pragma once
 
-#include "status.h"
+// The BUG macro wraps a function call and aborts the program with a debug message if the call
+// returns a non-OK status code.
+//
+// Usage:
+// BUG(my_critical_function_that_can_never_fail());
+//
+// BUG is meant to wrap operations where the only sensible thing to do on failure is to exit with
+// debugging information, such as initializing modules in main. If a BUG is triggered, it should
+// indicate a show-stopping bug that must be fixed before the project can run.
+//
+// Please DO NOT use this macro if it is possible for firmware to continue after a failure,
+// or if there is any possibility that it might be triggered in production (i.e. not as the result
+// of a serious and unrecoverable firmware bug). Instead, use status_ok_or_return from status.h,
+// or check the status yourself and handle any errors, even if the error handling is just a log.
 
 #define BUG(call)                                                                    \
   ({                                                                                 \
     __typeof__(call) status_code = (call);                                           \
     if (status_code) {                                                               \
-      Status global_status = status_get();                                           \
       LOG_CRITICAL(                                                                  \
-          "Bug triggered, aborting!\n"                                               \
+          "\n"                                                                       \
+          "****************** BUG TRIGGERED, ABORTING PROGRAM ******************\n"  \
           "This indicates initialization failure or another unrecoverable fault.\n"  \
           "Call returned status code %d:\n"                                          \
           "  %s\n"                                                                   \
-          "Location: %s:%d, in %s\n"                                                 \
-          "Info from last time status_code was called (may or may not be useful):\n" \
-          "  Status code: %d\n"                                                      \
-          "  Location: %s, in %s\n"                                                  \
-          "  Message: %s\n",                                                         \
-          status_code, #call, __FILE__, __LINE__, __FUNCTION__, global_status.code,  \
-          global_status.source, global_status.caller, global_status.message);        \
+          "in function %s\n"                                                         \
+          "at %s:%d\n"                                                               \
+          "*********************************************************************\n", \
+          status_code, #call, __FUNCTION__, __FILE__, __LINE__);                     \
+      /* Exit immediately, via a hard fault on STM32 or another method on x86. */    \
       __builtin_trap();                                                              \
     }                                                                                \
   })

--- a/projects/power_distribution/src/main.c
+++ b/projects/power_distribution/src/main.c
@@ -178,7 +178,7 @@ int main(void) {
     fan_settings.fan_pwm1 = FRONT_PD_PWM_1;
     fan_settings.fan_pwm2 = FRONT_PD_PWM_2;
   } else {
-    fan_settings.fan_pwm1 = REAR_ENC_VENT_PWM,
+    fan_settings.fan_pwm1 = REAR_ENC_VENT_PWM;
     fan_settings.fan_pwm2 = REAR_DCDC_PWM;
   }
   StatusCode fan_ctrl_status = pd_fan_ctrl_init(&fan_settings, is_front_pd);

--- a/projects/power_distribution/src/main.c
+++ b/projects/power_distribution/src/main.c
@@ -30,6 +30,7 @@
 #include "publish_data_config.h"
 #include "rear_strobe_blinker.h"
 #include "voltage_regulator.h"
+#include "wait.h"
 
 #define CURRENT_MEASUREMENT_INTERVAL_US 500000  // 0.5s between current measurements
 #define SIGNAL_BLINK_INTERVAL_US 500000         // 0.5s between blinks of the signal lights
@@ -211,6 +212,7 @@ int main(void) {
         rear_strobe_blinker_process_event(&e);
       }
     }
+    wait();
   }
 
   return 0;


### PR DESCRIPTION
In https://github.com/uw-midsun/firmware_xiv/pull/330 I added a `VERIFY_INIT` macro to make the PD main nicer, and Jess suggested it would be good as a libcore module. So here it is.

`BUG` wraps a call and `LOG_CRITICAL`s something like this when the call returns non-OK:
```
[2] projects/power_distribution/src/main.c:153:
****************** BUG TRIGGERED, ABORTING PROGRAM ******************
This indicates initialization failure or another unrecoverable fault.
Call returned status code 2:
  current_measurement_init(&current_measurement_settings)
in function main
at projects/power_distribution/src/main.c:153
*********************************************************************
```
Then it calls `__builtin_trap()` to exit immediately (via a hard fault on stm32, or something else like an illegal instruction on x86). The `***` is to draw attention to the debug output and away from the hard fault/illegal instruction output.

Also added a `wait()` in the PD event loop because it wasn't there before and that's bad for power consumption/my laptop fans.