### PR TITLE
[SOFT-460] Fix logging in MPXE

### DIFF
--- a/libraries/libcore/inc/log.h
+++ b/libraries/libcore/inc/log.h
@@ -39,11 +39,9 @@ typedef enum {
 #define MAX_LOG_LEN 256
 static char s_log_buf[MAX_LOG_LEN];
 
-// fflush necessary for printing through pipes
 #define LOG(level, fmt, ...)                                                                  \
   do {                                                                                        \
     if ((level) >= LOG_LEVEL_VERBOSITY) {                                                     \
-      store_config();                                                                         \
       memset(s_log_buf, 0, sizeof(s_log_buf));                                                \
       int len = snprintf(s_log_buf, sizeof(s_log_buf), "[%u] %s:%u: " fmt, (level), __FILE__, \
                          __LINE__, ##__VA_ARGS__);                                            \

--- a/libraries/libcore/inc/log.h
+++ b/libraries/libcore/inc/log.h
@@ -43,6 +43,7 @@ static char s_log_buf[MAX_LOG_LEN];
 #define LOG(level, fmt, ...)                                                                  \
   do {                                                                                        \
     if ((level) >= LOG_LEVEL_VERBOSITY) {                                                     \
+      store_config();                                                                         \
       memset(s_log_buf, 0, sizeof(s_log_buf));                                                \
       int len = snprintf(s_log_buf, sizeof(s_log_buf), "[%u] %s:%u: " fmt, (level), __FILE__, \
                          __LINE__, ##__VA_ARGS__);                                            \

--- a/libraries/mpxe-store/src/store.c
+++ b/libraries/mpxe-store/src/store.c
@@ -170,6 +170,7 @@ void store_export(MxStoreType type, void *store, void *key) {
 }
 
 void log_export(char *buf, uint16_t len) {
+  store_config();
   s_mxlog.log.len = len;
   s_mxlog.log.data = (uint8_t *)buf;
   store_export(MX_STORE_TYPE__LOG, &s_mxlog, NULL);


### PR DESCRIPTION
We previously wouldn't initialize `store` in the MPXE `LOG` implementation. This caused segfaults when using babydriver with MPXE, because it calls `LOG_DEBUG` first thing before any initialization. Fix by calling `store_config()` in `LOG`.