### PR TITLE
[SOFT-233] Adjust timings for MPXE

### DIFF
--- a/libraries/ms-helper/src/x86/ads1015.c
+++ b/libraries/ms-helper/src/x86/ads1015.c
@@ -23,6 +23,9 @@
 #define ADS1015_CHANNEL_ARBITRARY_READING 0
 
 #ifdef MPXE
+#undef ADS1015_CHANNEL_UPDATE_PERIOD_US
+#define ADS1015_CHANNEL_UPDATE_PERIODS_US 10000
+
 static MxAds1015Store s_store = MX_ADS1015_STORE__INIT;
 
 static void update_store(ProtobufCBinaryData msg_buf, ProtobufCBinaryData mask_buf) {

--- a/mpxe/integration_tests/test_ads1259.py
+++ b/mpxe/integration_tests/test_ads1259.py
@@ -11,9 +11,9 @@ class TestAds1259(int_test.IntTest):
         self.ads1259 = self.manager.start('smoke_ads1259', Ads1259())
 
     def test_ads1259(self):
-        time.sleep(1)
+        time.sleep(0.2)
         self.ads1259.sim.update_ads_reading(self.ads1259, 0x9A)
-        time.sleep(4)  # smoke test runs
+        time.sleep(0.2)  # smoke test runs
         self.ads1259.sim.assert_store_value_reading(self.ads1259, 0x9A)
 
 

--- a/mpxe/integration_tests/test_adt7476a.py
+++ b/mpxe/integration_tests/test_adt7476a.py
@@ -11,8 +11,8 @@ class TestAdt7476a(int_test.IntTest):
         self.adt7476a = self.manager.start('smoke_adt7476a', Adt7476a())
 
     def test_adt7476a(self):
-        for x in range(1, 10):
-            time.sleep(1)
+        for x in range(1, 3):
+            time.sleep(0.1)
             # this is for ADT_PWM_PORT_1
             self.adt7476a.sim.assert_store_values(self.adt7476a, x * 10, 0, 0)
             # this is for ADT_PWM_PORT_2

--- a/mpxe/integration_tests/test_leds.py
+++ b/mpxe/integration_tests/test_leds.py
@@ -11,7 +11,7 @@ class TestLeds(int_test.IntTest):
         self.leds = self.manager.start('leds', Leds())
 
     def test_leds(self):
-        time.sleep(1)
+        time.sleep(0.3)
 
 
 if __name__ == '__main__':

--- a/mpxe/integration_tests/test_mci.py
+++ b/mpxe/integration_tests/test_mci.py
@@ -11,22 +11,22 @@ class TestMci(int_test.IntTest):
         self.mci = self.manager.start('mci', Mci())
 
     def test_mci(self):
-        time.sleep(1)
+        time.sleep(0.3)
         self.assertNotEqual(self.mci.sim.tx_id, 0)
         self.assertEqual(self.mci.sim.tx_data, 0)
 
         self.manager.can.send('BEGIN_PRECHARGE', None)
-        time.sleep(1)
+        time.sleep(0.4)
         self.assert_can_received('PRECHARGE_COMPLETED')
 
         self.can_send('PEDAL_OUTPUT', {'throttle_output': 50, 'brake_output': 0})
-        time.sleep(1)
+        time.sleep(0.3)
         self.assertEqual(self.mci.sim.tx_data, 0)
 
         self.can_send('DRIVE_OUTPUT', {'drive_output': 1})
-        time.sleep(1)
+        time.sleep(0.3)
         self.can_send('PEDAL_OUTPUT', {'throttle_output': 50, 'brake_output': 0})
-        time.sleep(1)
+        time.sleep(0.3)
         self.assertNotEqual(self.mci.sim.tx_data, 0)
 
 

--- a/mpxe/integration_tests/test_pca9539r.py
+++ b/mpxe/integration_tests/test_pca9539r.py
@@ -21,7 +21,7 @@ class TestPca9539r(int_test.IntTest):
 
         value = 1
         for _ in range(1):
-            time.sleep(1)
+            time.sleep(0.5)
             for i in range(NUM_PCA_PINS):
                 self.pca9539r.sim.assert_store_values(i, value, pca_key)
             value = not value

--- a/mpxe/integration_tests/test_pedal.py
+++ b/mpxe/integration_tests/test_pedal.py
@@ -11,13 +11,13 @@ class TestPedal(int_test.IntTest):
         self.pedal = self.manager.start('pedal_board', PedalBoard())
 
     def test_pedal(self):
-        time.sleep(0.5)
+        time.sleep(0.3)
         # ads1015 reading is zero so throttle should be zero
         self.assert_can_data('PEDAL_OUTPUT', 'throttle_output', 0)
 
         # set throttle channel to 50
         self.pedal.sim.update_ads_reading(self.pedal, 50, 0)
-        time.sleep(0.5)
+        time.sleep(0.3)
         # ads1015 reading is nonzero so throttle should be nonzero
         self.assert_can_data('PEDAL_OUTPUT', 'throttle_output', 50)
 

--- a/projects/smoke_ads1259/src/main.c
+++ b/projects/smoke_ads1259/src/main.c
@@ -40,7 +40,7 @@ static void prv_periodic_read(SoftTimerId id, void *context) {
   } else {
     if (s_count <= READ_CYCLE_NUM * READ_CYCLE_SIZE || READ_CYCLE_NUM == 0) {
       s_index = 0;
-      soft_timer_start_millis(1000, prv_periodic_read, queue, NULL);
+      soft_timer_start_millis(100, prv_periodic_read, queue, NULL);
     } else {
       exit(0);
     }

--- a/projects/smoke_adt7476a/src/main.c
+++ b/projects/smoke_adt7476a/src/main.c
@@ -17,7 +17,7 @@
 
 #define ADT_7476A_NUM_FANS 4
 #define ADT_7476A_INTERRUPT_MASK_OFFSET 2
-#define SET_SPEED_INTERVAL_S 1
+#define SET_SPEED_INTERVAL_MS 100
 #define FAN_SPEED_INCREMENT 10
 #define I2C_WRITE_ADDR 0x5E
 #define I2C_READ_ADDR 0x5F
@@ -38,7 +38,7 @@ static void prv_periodic_set_speed(SoftTimerId id, void *context) {
   s_current_speed = s_current_speed % 101;
   LOG_DEBUG("SETTING SPEED: %d PERCENT\n", s_current_speed);
   adt7476a_set_speed(I2C_PORT, s_current_speed, ADT_PWM_PORT, I2C_WRITE_ADDR);
-  soft_timer_start_seconds(SET_SPEED_INTERVAL_S, prv_periodic_set_speed, NULL, NULL);
+  soft_timer_start_millis(SET_SPEED_INTERVAL_MS, prv_periodic_set_speed, NULL, NULL);
 }
 
 static void prv_callback(GpioAddress *address, void *context) {

--- a/projects/smoke_pca9539r/src/main.c
+++ b/projects/smoke_pca9539r/src/main.c
@@ -13,7 +13,7 @@
 #include "wait.h"
 
 // used to adjust time between gpio pin toggling
-#define WAIT_TIME_MILLIS 1000
+#define WAIT_TIME_MILLIS 500
 
 #define PCA9539_I2C_ADDRESS 0x74  // PCA9539 address
 #define I2C_PORT I2C_PORT_2


### PR DESCRIPTION
This adjusts some smoketest timings and driver timings to better accomodate mpxe by making integration tests run faster.

Smoketest timings have super minimal effects because users can always just adjust them manually when using them.

The change in ads1015 is because it was previously a 625 us loop, which caused perf issues with the latest soft_timer library changes and mpxe locking strategy. This is only on the x86 version, where there shouldn't be any necessity to be reading values at that frequency.