### PR TITLE
[SOFT-158] Fix a lot of bugs

### DIFF
--- a/libraries/ms-drivers/src/x86/pca9539r_gpio_expander.c
+++ b/libraries/ms-drivers/src/x86/pca9539r_gpio_expander.c
@@ -53,6 +53,9 @@ static void update_store(ProtobufCBinaryData msg_buf, ProtobufCBinaryData mask_b
 
 static void prv_init_store(uint8_t address) {
   store_config();
+  if (s_stores[address].state != NULL) {
+    free(s_stores[address].state);
+  }
   StoreFuncs funcs = {
     (GetPackedSizeFunc)mu_pca9539r_store__get_packed_size,
     (PackFunc)mu_pca9539r_store__pack,

--- a/libraries/mu-store/src/store.c
+++ b/libraries/mu-store/src/store.c
@@ -161,6 +161,10 @@ void store_register(MuStoreType type, StoreFuncs funcs, void *store, void *key) 
     LOG_DEBUG("invalid store\n");
     return;
   }
+  if (store_get(type, key)) {
+    return;
+  }
+
   s_func_table[type] = funcs;
   // malloc a proto as a store and return a pointer to it
   Store *local_store = prv_get_first_empty();

--- a/mu/harness/board_sim.py
+++ b/mu/harness/board_sim.py
@@ -64,11 +64,7 @@ class BoardSim:
         self.timers.append(timer)
         timer.start()
 
-    def get_gpio(self, port, pin):
-        gpio_msg = self.stores[GPIO_KEY]
-        return gpio_msg.state[(ord(port.capitalize()) - ord('A')) * 16 + pin]
-
-    def set_gpio(self, port, pin, state):
+    def make_gpio_update(self, port, pin, state):
         ind = (ord(port.capitalize()) - ord('A')) * 16 + pin
         gpio_msg = gpio_pb2.MuGpioStore()
         gpio_msg.state.extend([0] * 3 * 16)
@@ -76,7 +72,14 @@ class BoardSim:
         gpio_mask = gpio_pb2.MuGpioStore()
         gpio_mask.state.extend([0] * 3 * 16)
         gpio_mask.state[ind] = state
-        gpio_update = StoreUpdate(gpio_msg, gpio_mask, GPIO_KEY)
+        return StoreUpdate(gpio_msg, gpio_mask, GPIO_KEY)
+
+    def get_gpio(self, port, pin):
+        gpio_msg = self.stores[GPIO_KEY]
+        return gpio_msg.state[(ord(port.capitalize()) - ord('A')) * 16 + pin]
+
+    def set_gpio(self, port, pin, state):
+        gpio_update = self.make_gpio_update(port, pin, state)
 
         self.proj.write_store(gpio_update)
 

--- a/mu/integration_tests/deps.mk
+++ b/mu/integration_tests/deps.mk
@@ -9,3 +9,4 @@ MU_PROJS += smoke_adt7476a
 MU_PROJS += smoke_pca9539r
 MU_PROJS += smoke_mcp23008
 MU_PROJS += mu_init_conds
+MU_PROJS += power_distribution

--- a/mu/integration_tests/test_pd_init.py
+++ b/mu/integration_tests/test_pd_init.py
@@ -1,0 +1,21 @@
+import unittest
+import time
+
+from mu.integration_tests import int_test
+from mu.sims.front_pd import FrontPd
+
+
+class TestPdInit(int_test.IntTest):
+    def setUp(self):
+        super().setUp()
+        self.board = self.manager.start('power_distribution', FrontPd)
+
+    def test_front_init(self):
+        time.sleep(1)
+        init_pin = self.board.get_gpio('a', 8)
+        assert init_pin is False
+        self.assert_can_received('FRONT_CURRENT_MEASUREMENT')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/mu/sims/front_pd.py
+++ b/mu/sims/front_pd.py
@@ -4,4 +4,5 @@ from mu.sims.sub_sims.pca9539r import Pca9539r
 class FrontPd(BoardSim):
     def __init__(self, pm, proj_name):
         sub_sim_classes = [Pca9539r]
-        super().__init__(pm, proj_name, sub_sim_classes=sub_sim_classes)
+        init_cond = self.make_gpio_update('a', 8, False)
+        super().__init__(pm, proj_name, sub_sim_classes=sub_sim_classes, init_conds=[init_cond])


### PR DESCRIPTION
- Fix conceptual error in gpio MU: use input_pins correctly
- Fix memory leak in PCA9539r init pin: if already initialized, free the old store and use the new one
- Prevent initializing multiple stores with same key in store.c
- Add test for initializing PD to be the correct one
