### PR TITLE
[SOFT-380] Fix buffer overflow in MU logging

### DIFF
--- a/libraries/libcore/inc/log.h
+++ b/libraries/libcore/inc/log.h
@@ -32,20 +32,18 @@ typedef enum {
   } while (0)
 #else
 #include <stdbool.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "store.h"
 
-#define MAX_LOG_LEN 256
-static char s_log_buf[MAX_LOG_LEN];
-
-#define LOG(level, fmt, ...)                                                                  \
-  do {                                                                                        \
-    if ((level) >= LOG_LEVEL_VERBOSITY) {                                                     \
-      memset(s_log_buf, 0, sizeof(s_log_buf));                                                \
-      int len = snprintf(s_log_buf, sizeof(s_log_buf), "[%u] %s:%u: " fmt, (level), __FILE__, \
-                         __LINE__, ##__VA_ARGS__);                                            \
-      log_export(s_log_buf, len);                                                             \
-    }                                                                                         \
+#define LOG(level, fmt, ...)                                                                    \
+  do {                                                                                          \
+    if ((level) >= LOG_LEVEL_VERBOSITY) {                                                       \
+      char *log;                                                                                \
+      int len = asprintf(&log, "[%u] %s:%u: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
+      log_export(log, len);                                                                     \
+      free(log);                                                                                \
+    }                                                                                           \
   } while (0)
 #endif


### PR DESCRIPTION
The MU `LOG` implementation uses a static buffer to store logs to be exported. This was causing issues in PD, where use of the `BUG` macro would cause strings to exceed the 256-byte buffer (and gcc would actually detect this at compile time!).

To fix this, I got rid of the buffer entirely by using [`asprintf`](https://man7.org/linux/man-pages/man3/asprintf.3.html), a GNU extension which works like `snprintf` except it mallocs enough memory for the resulting string automatically. This does mean using the heap, but that's ok on MU since it's only for x86. Plus, we now don't have a `static char s_log_buf[256]` polluting the namespace of every file that includes log.h on MU.