### PR TITLE
[SOFT-233] Fix typo in CI script

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Build and test
         run: |
-          make build_all PLATFORM=stm32f0xx DEFINES="${DEFINES}"
+          make build_all PLATFORM=stm32f0xx DEFINE="${DEFINES}"
           make clean
           make build_all PLATFORM=x86 DEFINE="${DEFINES}"
           make test_all PLATFORM=x86 DEFINE="${DEFINES}"


### PR DESCRIPTION
I typo'd `DEFINES` instead of `DEFINE` when setting up the GitHub Actions CI script. That was causing STM32 builds to build with log-level debug instead of warn as it should be. Thanks @hewittmcg for finding this.