### PR TITLE
[SOFT-167] Fix a bunch of solar validation bugs

### DIFF
--- a/libraries/ms-drivers/inc/mcp3427_adc_defs.h
+++ b/libraries/ms-drivers/inc/mcp3427_adc_defs.h
@@ -17,4 +17,4 @@
 
 #define MCP3427_DATA_MASK_N_BIT(N) ((1 << N) - 1)
 
-#define MCP3427_MAX_CONV_TIME_MS 50
+#define MCP3427_MAX_CONV_TIME_MS 70

--- a/libraries/ms-drivers/src/stm32f0xx/mcp3427_adc.c
+++ b/libraries/ms-drivers/src/stm32f0xx/mcp3427_adc.c
@@ -144,6 +144,7 @@ StatusCode mcp3427_init(Mcp3427Storage *storage, Mcp3427Settings *settings) {
 
   storage->data_ready_event = settings->adc_data_ready_event;
   storage->data_trigger_event = settings->adc_data_trigger_event;
+  storage->sample_rate = settings->sample_rate;
 
   fsm_state_init(channel_1_trigger, prv_channel_trigger);
   fsm_state_init(channel_1_readback, prv_channel_ready);

--- a/libraries/ms-drivers/src/stm32f0xx/spv1020_mppt.c
+++ b/libraries/ms-drivers/src/stm32f0xx/spv1020_mppt.c
@@ -23,6 +23,14 @@ static StatusCode prv_send_command(SpiPort port, uint8_t command, uint8_t *rx_da
   return spi_exchange(port, &command, 1, rx_data, rx_len);
 }
 
+// Helper to send a command that expects a 16-bit reply.
+static StatusCode prv_send_command_uint16_reply(SpiPort port, uint8_t command, uint16_t *reply) {
+  uint8_t rx_data[2] = { 0 };
+  StatusCode code = prv_send_command(port, command, rx_data, 2);
+  *reply = (rx_data[0] << 8) | rx_data[1];
+  return code;
+}
+
 StatusCode spv1020_shut(SpiPort port) {
   return prv_send_command(port, SPV1020_CMD_SHUT, NULL, 0);
 }
@@ -32,16 +40,16 @@ StatusCode spv1020_turn_on(SpiPort port) {
 }
 
 StatusCode spv1020_read_current(SpiPort port, uint16_t *current) {
-  return prv_send_command(port, SPV1020_CMD_READ_CURRENT, (uint8_t *)current, 2);
+  return prv_send_command_uint16_reply(port, SPV1020_CMD_READ_CURRENT, current);
 }
 
 StatusCode spv1020_read_voltage_in(SpiPort port, uint16_t *vin) {
-  return prv_send_command(port, SPV1020_CMD_READ_VIN, (uint8_t *)vin, 2);
+  return prv_send_command_uint16_reply(port, SPV1020_CMD_READ_VIN, vin);
 }
 
 StatusCode spv1020_read_pwm(SpiPort port, uint16_t *pwm) {
   uint16_t raw_pwm;
-  StatusCode code = prv_send_command(port, SPV1020_CMD_READ_PWM, (uint8_t *)&raw_pwm, 2);
+  StatusCode code = prv_send_command_uint16_reply(port, SPV1020_CMD_READ_PWM, &raw_pwm);
 
   // Convert the raw 9-bit value to a permille. The application note says that the PWM duty cycle
   // ranges from 5% to 90% with a step of 0.2%, giving 425 values; we assume that the raw value

--- a/libraries/ms-drivers/test/test_spv1020_mppt.c
+++ b/libraries/ms-drivers/test/test_spv1020_mppt.c
@@ -6,7 +6,7 @@
 
 #define TEST_SPI_PORT SPI_PORT_2
 
-#define TEST_BAUDRATE 60000
+#define TEST_BAUDRATE 6000000
 #define TEST_MOSI_PIN \
   { .port = GPIO_PORT_B, 15 }
 #define TEST_MISO_PIN \
@@ -19,7 +19,7 @@
 void setup_test() {
   gpio_init();
   SpiSettings spi_settings = {
-    .baudrate = 60000,
+    .baudrate = TEST_BAUDRATE,
     .mode = SPI_MODE_3,
     .mosi = TEST_MOSI_PIN,
     .miso = TEST_MISO_PIN,

--- a/projects/smoke_mcp3427/rules.mk
+++ b/projects/smoke_mcp3427/rules.mk
@@ -6,4 +6,4 @@
 # $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the libraries you want to include
-$(T)_DEPS := ms-common ms-drivers
+$(T)_DEPS := ms-helpers ms-common ms-drivers

--- a/projects/smoke_mcp3427/rules.mk
+++ b/projects/smoke_mcp3427/rules.mk
@@ -6,4 +6,4 @@
 # $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the libraries you want to include
-$(T)_DEPS := ms-helpers ms-common ms-drivers
+$(T)_DEPS := ms-helper ms-common ms-drivers

--- a/projects/smoke_mcp3427/src/main.c
+++ b/projects/smoke_mcp3427/src/main.c
@@ -6,6 +6,7 @@
 // https://uwmidsun.atlassian.net/wiki/spaces/ELEC/pages/1475543041/MCP3427+smoke+test+user+guide
 #include "mcp3427_adc.h"
 
+#include "controller_board_pins.h"
 #include "event_queue.h"
 #include "gpio.h"
 #include "i2c.h"
@@ -22,17 +23,6 @@
 #define SMOKE_SAMPLE_RATE MCP3427_SAMPLE_RATE_12_BIT
 #define SMOKE_AMP_GAIN MCP3427_AMP_GAIN_1
 #define SMOKE_CONVERSION_MODE MCP3427_CONVERSION_MODE_ONE_SHOT
-
-// I2C settings
-#define I2C1_SDA \
-  { .port = GPIO_PORT_B, .pin = 11 }
-#define I2C1_SCL \
-  { .port = GPIO_PORT_B, .pin = 10 }
-
-#define I2C2_SDA \
-  { .port = GPIO_PORT_B, .pin = 9 }
-#define I2C2_SCL \
-  { .port = GPIO_PORT_B, .pin = 8 }
 
 // Unique ID of each MCP3427
 typedef enum {
@@ -172,15 +162,15 @@ int main() {
 
   I2CSettings i2c1_settings = {
     .speed = I2C_SPEED_FAST,
-    .sda = I2C1_SDA,
-    .scl = I2C1_SCL,
+    .sda = CONTROLLER_BOARD_ADDR_I2C1_SDA,
+    .scl = CONTROLLER_BOARD_ADDR_I2C1_SCL,
   };
   i2c_init(I2C_PORT_1, &i2c1_settings);
 
   I2CSettings i2c2_settings = {
     .speed = I2C_SPEED_FAST,
-    .sda = I2C2_SDA,
-    .scl = I2C2_SCL,
+    .sda = CONTROLLER_BOARD_ADDR_I2C2_SDA,
+    .scl = CONTROLLER_BOARD_ADDR_I2C2_SCL,
   };
   i2c_init(I2C_PORT_2, &i2c2_settings);
 

--- a/projects/smoke_mcp3427/src/main.c
+++ b/projects/smoke_mcp3427/src/main.c
@@ -61,7 +61,7 @@ typedef struct SmokeMcp3427Data {
 } SmokeMcp3427Data;
 
 #define MAX_NUM_MCP3427 7
-static SmokeMcp3427Data s_mcp3427_data[MAX_NUM_MCP3427];
+static SmokeMcp3427Data s_mcp3427_data[MAX_NUM_MCP3427] = { 0 };
 // s_test_devices: hold the indices of specific mcp3427s being tested.
 // Voltage sense mcp3427 indices: 0 to 5.
 // Current sense mcp3427 indices: 6
@@ -123,7 +123,7 @@ static Mcp3427Settings s_mcp3427_configs[MAX_NUM_MCP3427] = {
   {
       .port = I2C_PORT_2,
       .addr_pin_0 = MCP3427_PIN_STATE_FLOAT,
-      .addr_pin_1 = MCP3427_PIN_STATE_HIGH,
+      .addr_pin_1 = MCP3427_PIN_STATE_LOW,
       .sample_rate = SMOKE_SAMPLE_RATE,
       .amplifier_gain = SMOKE_AMP_GAIN,
       .conversion_mode = SMOKE_CONVERSION_MODE,

--- a/projects/smoke_spi/src/main.c
+++ b/projects/smoke_spi/src/main.c
@@ -17,7 +17,7 @@ static uint8_t tx_bytes[] = { 0b00000001, 0b00001111 };
 static SpiPort port_to_use = SPI_PORT_2;
 
 const SpiSettings settings_to_use = {
-  .baudrate = 60000,
+  .baudrate = 6000000,
   .mode = SPI_MODE_0,
   // Adjust GPIO pins as needed
   .mosi = { .port = GPIO_PORT_B, 15 },

--- a/projects/smoke_spv1020/src/main.c
+++ b/projects/smoke_spv1020/src/main.c
@@ -28,7 +28,7 @@
 // modify if you want to read more or less
 #define SMOKETEST_WAIT_TIME_MS 1000
 
-#define BAUDRATE 60000
+#define BAUDRATE 6000000
 #define MOSI_PIN \
   { .port = GPIO_PORT_B, 15 }
 #define MISO_PIN \

--- a/projects/solar/inc/pin_defs.h
+++ b/projects/solar/inc/pin_defs.h
@@ -9,27 +9,6 @@
 #define MPPT_COUNT_DETECTION_PIN \
   { GPIO_PORT_A, 7 }
 
-#define SOLAR_I2C1_SDA \
-  { GPIO_PORT_B, 11 }
-#define SOLAR_I2C1_SCL \
-  { GPIO_PORT_B, 10 }
-#define SOLAR_I2C2_SDA \
-  { GPIO_PORT_B, 9 }
-#define SOLAR_I2C2_SCL \
-  { GPIO_PORT_B, 8 }
-
-#define SOLAR_SPI2_MOSI \
-  { GPIO_PORT_B, 15 }
-#define SOLAR_SPI2_MISO \
-  { GPIO_PORT_B, 14 }
-#define SOLAR_SPI2_SCLK \
-  { GPIO_PORT_B, 13 }
-
-#define SOLAR_CAN_RX_PIN \
-  { GPIO_PORT_A, 12 }
-#define SOLAR_CAN_TX_PIN \
-  { GPIO_PORT_A, 11 }
-
 #define MUX_SEL_PIN_0 \
   { GPIO_PORT_B, 0 }
 #define MUX_SEL_PIN_1 \

--- a/projects/solar/rules.mk
+++ b/projects/solar/rules.mk
@@ -6,7 +6,7 @@
 # $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the libraries you want to include
-$(T)_DEPS := ms-common ms-drivers
+$(T)_DEPS := ms-helpers ms-common ms-drivers
 
 $(T)_test_mppt_MOCKS := mux_set
 

--- a/projects/solar/rules.mk
+++ b/projects/solar/rules.mk
@@ -6,7 +6,7 @@
 # $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the libraries you want to include
-$(T)_DEPS := ms-helpers ms-common ms-drivers
+$(T)_DEPS := ms-helper ms-common ms-drivers
 
 $(T)_test_mppt_MOCKS := mux_set
 

--- a/projects/solar/src/solar_config.c
+++ b/projects/solar/src/solar_config.c
@@ -79,7 +79,7 @@ static const I2CSettings s_i2c2_settings = {
 };
 
 static const SpiSettings s_spi_settings = {
-  .baudrate = 60000,
+  .baudrate = 6000000,
   .mode = SPI_MODE_3,
   .mosi = SOLAR_SPI2_MOSI,
   .miso = SOLAR_SPI2_MISO,

--- a/projects/solar/src/solar_config.c
+++ b/projects/solar/src/solar_config.c
@@ -1,6 +1,7 @@
 #include "solar_config.h"
 
 #include "can_msg_defs.h"
+#include "controller_board_pins.h"
 #include "data_store.h"
 #include "data_tx.h"
 #include "exported_enums.h"
@@ -68,22 +69,22 @@
 
 static const I2CSettings s_i2c1_settings = {
   .speed = SOLAR_I2C_SPEED,
-  .sda = SOLAR_I2C1_SDA,
-  .scl = SOLAR_I2C1_SCL,
+  .sda = CONTROLLER_BOARD_ADDR_I2C1_SDA,
+  .scl = CONTROLLER_BOARD_ADDR_I2C1_SCL,
 };
 
 static const I2CSettings s_i2c2_settings = {
   .speed = SOLAR_I2C_SPEED,
-  .sda = SOLAR_I2C2_SDA,
-  .scl = SOLAR_I2C2_SCL,
+  .sda = CONTROLLER_BOARD_ADDR_I2C2_SDA,
+  .scl = CONTROLLER_BOARD_ADDR_I2C2_SCL,
 };
 
 static const SpiSettings s_spi_settings = {
   .baudrate = 6000000,
   .mode = SPI_MODE_3,
-  .mosi = SOLAR_SPI2_MOSI,
-  .miso = SOLAR_SPI2_MISO,
-  .sclk = SOLAR_SPI2_SCLK,
+  .mosi = CONTROLLER_BOARD_ADDR_SPI2_MOSI,
+  .miso = CONTROLLER_BOARD_ADDR_SPI2_MISO,
+  .sclk = CONTROLLER_BOARD_ADDR_SPI2_SCK,
   .cs = SOLAR_UNUSED_PIN,
 };
 
@@ -93,8 +94,8 @@ static CanSettings s_can_settings = {
   .rx_event = SOLAR_CAN_EVENT_RX,
   .tx_event = SOLAR_CAN_EVENT_TX,
   .fault_event = SOLAR_CAN_EVENT_FAULT,
-  .rx = SOLAR_CAN_RX_PIN,
-  .tx = SOLAR_CAN_TX_PIN,
+  .rx = CONTROLLER_BOARD_ADDR_CAN_RX,
+  .tx = CONTROLLER_BOARD_ADDR_CAN_TX,
   .loopback = false,
 };
 

--- a/projects/solar/src/solar_config.c
+++ b/projects/solar/src/solar_config.c
@@ -247,8 +247,8 @@ static SenseMcp3427Settings s_sense_mcp3427_settings = {
               .mcp3427_settings =
                   {
                       .port = I2C_PORT_2,
-                      .addr_pin_0 = MCP3427_PIN_STATE_FLOAT,
-                      .addr_pin_1 = MCP3427_PIN_STATE_HIGH,
+                      .addr_pin_0 = MCP3427_PIN_STATE_HIGH,
+                      .addr_pin_1 = MCP3427_PIN_STATE_FLOAT,
                       .sample_rate = SOLAR_MCP3427_SAMPLE_RATE,
                       .amplifier_gain = SOLAR_MCP3427_VOLTAGE_SENSE_AMP_GAIN,
                       .conversion_mode = SOLAR_MCP3427_CONVERSION_MODE,


### PR DESCRIPTION
These were actually discovered and fixed in like September, for some reason I never put up a PR for them. So here they are.

Changes in order of appearance:
* Increase the max MCP3427 conversion time which we wait before checking for a conversion, because I think it was throwing too many errors.
* Actually assign the sample rate from the settings to the storage in MCP3427, we weren't doing that before and it was defaulting to 16 bits (slowest and most precise).
* Fix an endianness issue in the SPV1020 driver, it turns out the SPV1020 is big-endian while the STM32 is little-endian. Plus, relying on the endianness of the host system is a bad idea anyways.
* Increase the SPI baudrate from 60000 to the 6000000 value we use everywhere else in the SPI and SPV1020 smoketests, plus a few tests and solar itself.
* A couple MCP3427 address configs were misconfigured in solar, fix those.
* The I2C1 and I2C2 pins were swapped in the MCP3427 smoketest and in solar. Fixed that by using the standard macros from controller_board_pins.h instead.