### PR TITLE
[SOFT-484] Implement viewing and updating stores

### DIFF
--- a/libraries/ms-common/src/x86/adc.c
+++ b/libraries/ms-common/src/x86/adc.c
@@ -51,6 +51,7 @@ static void update_store(ProtobufCBinaryData msg_buf, ProtobufCBinaryData mask_b
   }
   mu_adc_store__free_unpacked(msg, NULL);
   mu_adc_store__free_unpacked(mask, NULL);
+  store_export(MU_STORE_TYPE__ADC, &s_store, NULL);
 }
 
 static void prv_init_store() {
@@ -65,6 +66,7 @@ static void prv_init_store() {
   s_store.reading = malloc(NUM_ADC_CHANNELS * sizeof(uint32_t));
 
   store_register(MU_STORE_TYPE__ADC, funcs, &s_store, NULL);
+  store_export(MU_STORE_TYPE__ADC, &s_store, NULL);
 }
 #endif
 

--- a/libraries/ms-drivers/src/ads1259_adc.c
+++ b/libraries/ms-drivers/src/ads1259_adc.c
@@ -44,6 +44,7 @@ static void update_store(ProtobufCBinaryData msg_buf, ProtobufCBinaryData mask_b
   }
   mu_ads1259_store__free_unpacked(msg, NULL);
   mu_ads1259_store__free_unpacked(mask, NULL);
+  store_export(MU_STORE_TYPE__ADS1259, &s_store, NULL);
 }
 
 static void prv_init_store(void) {
@@ -56,6 +57,7 @@ static void prv_init_store(void) {
     (UpdateStoreFunc)update_store,
   };
   store_register(MU_STORE_TYPE__ADS1259, funcs, &s_store, NULL);
+  store_export(MU_STORE_TYPE__ADS1259, &s_store, NULL);
 }
 
 #endif

--- a/libraries/ms-drivers/src/adt7476a_fan_controller.c
+++ b/libraries/ms-drivers/src/adt7476a_fan_controller.c
@@ -48,6 +48,7 @@ static void prv_init_store(void) {
   s_store.n_status = NUM_ADT_PWM_PORTS;
   s_store.status = malloc(NUM_ADT_PWM_PORTS * sizeof(protobuf_c_boolean));
   store_register(MU_STORE_TYPE__ADT7476A, funcs, &s_store, NULL);
+  store_export(MU_STORE_TYPE__ADT7476A, &s_store, NULL);
 }
 #endif
 

--- a/libraries/ms-helper/src/x86/ads1015.c
+++ b/libraries/ms-helper/src/x86/ads1015.c
@@ -40,6 +40,7 @@ static void update_store(ProtobufCBinaryData msg_buf, ProtobufCBinaryData mask_b
 
   mu_ads1015_store__free_unpacked(msg, NULL);
   mu_ads1015_store__free_unpacked(mask, NULL);
+  store_export(MU_STORE_TYPE__ADS1015, &s_store, NULL);
 }
 
 static void prv_init_store(void) {
@@ -54,6 +55,7 @@ static void prv_init_store(void) {
   s_store.n_readings = NUM_ADS1015_CHANNELS;
   s_store.readings = malloc(NUM_ADS1015_CHANNELS * sizeof(int32_t));
   store_register(MU_STORE_TYPE__ADS1015, funcs, &s_store, NULL);
+  store_export(MU_STORE_TYPE__ADS1015, &s_store, NULL);
 }
 #endif
 

--- a/libraries/mu-store/src/store.c
+++ b/libraries/mu-store/src/store.c
@@ -79,7 +79,9 @@ static void prv_handle_store_update(uint8_t *buf, int64_t len) {
     }
   } else {
     if (s_init_cond_complete) {  // Default activity, call update store for type
-      s_func_table[update->type].update_store(update->msg, update->mask, (void *)update->key);
+      if (s_func_table[update->type].update_store) {
+        s_func_table[update->type].update_store(update->msg, update->mask, (void *)update->key);
+      }
       mu_store_update__free_unpacked(update, NULL);
     } else {  // Store initial conditions to be used in store_register
       if (s_num_init_conds < MAX_STORE_COUNT) {

--- a/mu/ctl/args.py
+++ b/mu/ctl/args.py
@@ -42,4 +42,13 @@ def get_args():
     update.add_argument('key', nargs='?', default='')
     update.set_defaults(func=stores.update)
 
+    get_io = subparsers.add_parser('get', help='get sim inputs and outputs')
+    get_io.add_argument('name', nargs='?', default='')
+    get_io.set_defaults(func=stores.get_io)
+
+    set_io = subparsers.add_parser('set', help='set sim inputs')
+    set_io.add_argument('name')
+    set_io.add_argument('val')
+    set_io.set_defaults(func=stores.set_io)
+
     return parser.parse_args()

--- a/mu/ctl/args.py
+++ b/mu/ctl/args.py
@@ -1,6 +1,7 @@
 import argparse
 from mu.ctl.log import logs
 from mu.ctl import sims
+from mu.ctl import stores
 
 def get_args():
     parser = argparse.ArgumentParser(prog='muctl', description='interact with musrv')
@@ -28,5 +29,17 @@ def get_args():
 
     sim_list = subparsers.add_parser('list', help='list running sims')
     sim_list.set_defaults(func=sims.sim_list)
+
+    view = subparsers.add_parser('view', help='view sim stores')
+    view.add_argument('sim')
+    view.add_argument('store_type', nargs='?', default='')
+    view.add_argument('key', nargs='?', default='')
+    view.set_defaults(func=stores.view)
+
+    update = subparsers.add_parser('update', help='update a store')
+    update.add_argument('sim')
+    update.add_argument('store_type')
+    update.add_argument('key', nargs='?', default='')
+    update.set_defaults(func=stores.update)
 
     return parser.parse_args()

--- a/mu/ctl/req.py
+++ b/mu/ctl/req.py
@@ -1,7 +1,6 @@
 import requests
 from mu.srv.server import TCP_PORT
 
-def send(route, body=None):
+def send(route, params=None, body=None):
     url = 'http://localhost:{}/{}'.format(TCP_PORT, route)
-    r = requests.get(url, params=body)
-    return r.text
+    return requests.get(url, params=params, json=body)

--- a/mu/ctl/sims.py
+++ b/mu/ctl/sims.py
@@ -4,28 +4,28 @@ import mu.ctl.req as req
 
 def reset(args):
     r = req.send('reset')
-    print(r)
+    print(r.text)
 
 def start(args):
-    body = { 'sim': args.sim, 'proj': args.proj }
-    r = req.send('start', body)
-    print(r)
+    params = { 'sim': args.sim, 'proj': args.proj }
+    r = req.send('start', params)
+    print(r.text)
 
 def stop(args):
-    body = { 'sim': args.sim }
-    r = req.send('stop', body)
-    print(r)
+    params = { 'sim': args.sim }
+    r = req.send('stop', params)
+    print(r.text)
 
 def sims(args):
     r = req.send('sims')
-    sims = json.loads(r)
+    sims = json.loads(r.text)
     print('Available sims:')
     for sim in sims:
         print(sim)
 
 def sim_list(args):
     r = req.send('list')
-    sims = json.loads(r)
+    sims = json.loads(r.text)
     print('Running sims:')
     for sim in sims:
         print(sim)

--- a/mu/ctl/stores.py
+++ b/mu/ctl/stores.py
@@ -1,0 +1,32 @@
+import json
+import pprint
+import tempfile
+import subprocess
+
+import mu.ctl.req as req
+
+def view(args):
+    params = { 'sim': args.sim, 'type': args.store_type, 'key': args.key }
+    r = req.send('view', params)
+    if r.status_code == 200:
+        pprint.pprint(json.loads(r.text), indent=2)
+    else:
+        print(r.text)
+
+def update(args):
+    params = { 'sim': args.sim, 'type': args.store_type, 'key': args.key }
+    r = req.send('view', params)
+    if r.status_code != 200:
+        print(r.text)
+        return
+    tf = tempfile.NamedTemporaryFile(suffix='.tmp')
+    tf.write(r.text.encode())
+    tf.flush()
+
+    subprocess.call(['vim', tf.name])
+
+    tf.seek(0)
+    edited = tf.read().decode()
+
+    r = req.send('apply', params, edited)
+    print(r.text)

--- a/mu/ctl/stores.py
+++ b/mu/ctl/stores.py
@@ -30,3 +30,13 @@ def update(args):
 
     r = req.send('apply', params, edited)
     print(r.text)
+
+def get_io(args):
+    params = { 'name': args.name }
+    r = req.send('get', params)
+    print(r.text)
+
+def set_io(args):
+    params = { 'name': args.name, 'val': args.val }
+    r = req.send('set', params)
+    print(r.text)

--- a/mu/harness/board_sim.py
+++ b/mu/harness/board_sim.py
@@ -23,6 +23,7 @@ class BoardSim:
                 self.sub_sims[sub_sim_class.__name__.lower()] = sub_sim_class(self)
         self.stores = {}
         self.timers = []
+        self.simios = {}
         self.proj = project.Project(pm, self, proj_name)
         self.fd = self.proj.popen.stdout.fileno()
         self.pm.register(self)

--- a/mu/harness/board_sim.py
+++ b/mu/harness/board_sim.py
@@ -23,7 +23,6 @@ class BoardSim:
                 self.sub_sims[sub_sim_class.__name__.lower()] = sub_sim_class(self)
         self.stores = {}
         self.timers = []
-        self.simios = {}
         self.proj = project.Project(pm, self, proj_name)
         self.fd = self.proj.popen.stdout.fileno()
         self.pm.register(self)
@@ -88,7 +87,7 @@ class BoardSim:
     def stores_str_lookup(self, store_type, store_key):
         for key in self.stores:
             if key[0] == stores_pb2.MuStoreType.Value(store_type.upper()):
-                if store_key and not int(store_key, 0) == key[0]:
+                if store_key and int(store_key, 0) != key[0]:
                     continue
                 return self.stores[key]
         raise ValueError('No such store')

--- a/mu/harness/board_sim.py
+++ b/mu/harness/board_sim.py
@@ -84,6 +84,14 @@ class BoardSim:
 
         self.proj.write_store(gpio_update)
 
+    def stores_str_lookup(self, store_type, store_key):
+        for key in self.stores:
+            if key[0] == stores_pb2.MuStoreType.Value(store_type.upper()):
+                if store_key and not int(store_key, 0) == key[0]:
+                    continue
+                return self.stores[key]
+        raise ValueError('No such store')
+
     # To be implemented by subclasses
 
     def handle_store(self, store, key):

--- a/mu/harness/decoder.py
+++ b/mu/harness/decoder.py
@@ -5,18 +5,33 @@ from mu.protogen import stores_pb2
 MODULE_NAME_FORMAT = 'mu.protogen.{}_pb2'
 STORE_TYPE_NAME_FORMAT = 'Mu{}Store'
 
+def store_from_name(type_name):
+    type_name = type_name.lower()
+    # get class from module via introspection
+    type_module = importlib.import_module(MODULE_NAME_FORMAT.format(type_name))
+    store_class = getattr(type_module, STORE_TYPE_NAME_FORMAT.format(type_name.capitalize()))
+    return store_class()
+
+def store_from_enum(store_enum):
+    # grab enum name from enum value for introspection
+    type_name = stores_pb2.MuStoreType.Name(store_enum).lower()
+    return store_from_name(type_name)
 
 def decode_store_info(msg):
     store_info = stores_pb2.MuStoreInfo()
     store_info.ParseFromString(msg)
     return store_info
 
-
 def decode_store(store_info):
-    # grab enum name from enum value for introspection
-    type_str = stores_pb2.MuStoreType.Name(store_info.type).lower()
-    # get class from module via introspection
-    type_module = importlib.import_module(MODULE_NAME_FORMAT.format(type_str))
-    store = getattr(type_module, STORE_TYPE_NAME_FORMAT.format(type_str.capitalize()))()
+    store = store_from_enum(store_info.type)
     store.ParseFromString(store_info.msg)
     return store
+
+def full_mask(store):
+    mask = store.__class__()
+    for descriptor, val in store.ListFields():
+        if hasattr(val, '__len__'):
+            getattr(mask, descriptor.name).extend([1] * len(val))
+        else:
+            setattr(mask, descriptor.name, 1)
+    return mask

--- a/mu/harness/pm.py
+++ b/mu/harness/pm.py
@@ -89,6 +89,13 @@ class ProjectManager:
 
     def stop(self, sim):
         del self.fd_to_sim[sim.fd]
+        # avoid deleting from self.simios during iteration
+        simios = []
+        for name, simio in self.simios.items():
+            if simio.sim == sim:
+                simios.append(name)
+        for simio in simios:
+            del self.simios[simio]
         sim.stop()
 
     def stop_name(self, sim_name):
@@ -186,7 +193,7 @@ class ProjectManager:
 
     def get_all_io(self):
         ret = {}
-        for name, simio in self.simios:
+        for name, simio in self.simios.items():
             ret[name] = simio.get()
         return ret
 

--- a/mu/harness/pm.py
+++ b/mu/harness/pm.py
@@ -30,6 +30,7 @@ class ProjectManager:
         print('Configuration:', config)
         self.config = config
         self.fd_to_sim = {}
+        self.simios = {}
         self.proj_name_list = os.listdir(os.path.join(REPO_DIR, 'projects'))
         self.sim_catalog = self.sim_cat()
         self.killed = False
@@ -174,6 +175,23 @@ class ProjectManager:
                     continue
                 catalog[sim_name] = sim_class
         return catalog
+
+    def new_io(self, simio):
+        if simio.name in self.simios:
+            raise ValueError('SimIo name taken')
+        self.simios[simio.name] = simio
+
+    def get_io(self, name):
+        return self.simios[name].get()
+
+    def get_all_io(self):
+        ret = {}
+        for name, simio in self.simios:
+            ret[name] = simio.get()
+        return ret
+
+    def set_io(self, name, val):
+        self.simios[name].set(val)
 
     def end(self):
         self.killed = True

--- a/mu/harness/pm.py
+++ b/mu/harness/pm.py
@@ -80,16 +80,19 @@ class ProjectManager:
     def register(self, sim):
         self.fd_to_sim[sim.fd] = sim
 
+    def sim_from_name(self, sim_name):
+        for sim in self.fd_to_sim.values():
+            if sim.__class__.__name__ == sim_name:
+                return sim
+        raise ValueError('Invalid sim, check list')
+
     def stop(self, sim):
         del self.fd_to_sim[sim.fd]
         sim.stop()
 
     def stop_name(self, sim_name):
-        for sim in self.fd_to_sim.values():
-            if sim.__class__.__name__ == sim_name:
-                self.stop(sim)
-                return
-        raise ValueError('Invalid sim, check list')
+        sim = self.sim_from_name(sim_name)
+        self.stop(sim)
 
     def stop_all(self):
         for sim in self.fd_to_sim.values():

--- a/mu/harness/sim_io.py
+++ b/mu/harness/sim_io.py
@@ -1,5 +1,6 @@
 class SimIo:
-    def __init__(self, name, getter, setter):
+    def __init__(self, sim, name, getter, setter):
+        self.sim = sim
         self.name = name
         self.getter = getter
         self.setter = setter

--- a/mu/harness/sim_io.py
+++ b/mu/harness/sim_io.py
@@ -1,0 +1,15 @@
+class SimIo:
+    def __init__(self, name, getter, setter):
+        self.name = name
+        self.getter = getter
+        self.setter = setter
+
+    def get(self):
+        if self.getter is None:
+            raise NotImplementedError
+        return self.getter()
+
+    def set(self, val):
+        if self.setter is None:
+            raise NotImplementedError
+        self.setter(val)

--- a/mu/sims/pedal_board.py
+++ b/mu/sims/pedal_board.py
@@ -6,8 +6,8 @@ from mu.sims.sub_sims.ads1015 import Ads1015, ADS1015_KEY
 class PedalBoard(BoardSim):
     def __init__(self, pm, proj_name='pedal_board'):
         super().__init__(pm, proj_name, sub_sim_classes=[Ads1015])
-        self.pm.new_io(SimIo('throttle', self.get_throttle, self.set_throttle))
-        self.pm.new_io(SimIo('brake', self.get_brake, self.set_brake))
+        self.pm.new_io(SimIo(self, 'throttle', self.get_throttle, self.set_throttle))
+        self.pm.new_io(SimIo(self, 'brake', self.get_brake, self.set_brake))
 
     def get_throttle(self):
         return self.stores[ADS1015_KEY].readings[0]

--- a/mu/sims/pedal_board.py
+++ b/mu/sims/pedal_board.py
@@ -1,7 +1,22 @@
 from mu.harness.board_sim import BoardSim
-from mu.sims.sub_sims.ads1015 import Ads1015
+from mu.harness.sim_io import SimIo
+from mu.sims.sub_sims.ads1015 import Ads1015, ADS1015_KEY
 
 
 class PedalBoard(BoardSim):
     def __init__(self, pm, proj_name='pedal_board'):
         super().__init__(pm, proj_name, sub_sim_classes=[Ads1015])
+        self.pm.new_io(SimIo('throttle', self.get_throttle, self.set_throttle))
+        self.pm.new_io(SimIo('brake', self.get_brake, self.set_brake))
+
+    def get_throttle(self):
+        return self.stores[ADS1015_KEY].readings[0]
+
+    def get_brake(self):
+        return self.stores[ADS1015_KEY].readings[1]
+
+    def set_throttle(self, val):
+        self.sub_sims['ads1015'].update_reading(0, int(val))
+
+    def set_brake(self, val):
+        self.sub_sims['ads1015'].update_reading(1, int(val))

--- a/mu/srv/handler.py
+++ b/mu/srv/handler.py
@@ -28,6 +28,8 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
 
             'view': self.view,
             'apply': self.apply,
+            'get': self.get,
+            'set': self.set,
         }
 
     def respond(self, code, body='{"acknowledged": "true"}'):
@@ -141,4 +143,25 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
             sim.proj.write_store(update)
             self.respond(200)
         except ValueError as e:
+            self.respond(500, body='{}'.format(e))
+
+    def get(self, params=None):
+        io_name = params['name'][0]
+        try:
+            if io_name:
+                val = self.pm.get_io(io_name)
+                self.respond(200, body='{}'.format(val))
+            else:
+                vals = self.pm.get_all_io()
+                self.respond(200, body=json.dumps(vals))
+        except (KeyError, ValueError, NotImplementedError) as e:
+            self.respond(500, body='{}'.format(e))
+
+    def set(self, params=None):
+        io_name = params['name'][0]
+        val = params['val'][0]
+        try:
+            val = self.pm.set_io(io_name, val)
+            self.respond(200)
+        except (KeyError, ValueError, NotImplementedError) as e:
             self.respond(500, body='{}'.format(e))

--- a/mu/srv/handler.py
+++ b/mu/srv/handler.py
@@ -64,14 +64,14 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
             self.pm.start(params['sim'][0], proj_name=params['proj'][0])
             self.respond(200)
         except ValueError as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
 
     def stop(self, params=None):
         try:
             self.pm.stop_name(params['sim'][0])
             self.respond(200)
         except ValueError as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
 
     def sims(self, params=None):
         sim_list = list(self.pm.sim_cat().keys())
@@ -116,7 +116,7 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
                 stores_json = json.dumps(store_dicts)
                 self.respond(200, body=stores_json)
         except ValueError as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
 
     def apply(self, params=None):
         sim_name = params['sim'][0]
@@ -131,7 +131,7 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
             store_dict = json.loads(store_json)
             json_format.Parse(store_dict, store)
         except json_format.ParseError as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
             return
 
         mask = decoder.full_mask(store)
@@ -143,7 +143,7 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
             sim.proj.write_store(update)
             self.respond(200)
         except ValueError as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
 
     def get(self, params=None):
         io_name = params['name'][0]
@@ -155,7 +155,7 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
                 vals = self.pm.get_all_io()
                 self.respond(200, body=json.dumps(vals))
         except (KeyError, ValueError, NotImplementedError) as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))
 
     def set(self, params=None):
         io_name = params['name'][0]
@@ -164,4 +164,4 @@ class ReqHandler(http.server.BaseHTTPRequestHandler):
             val = self.pm.set_io(io_name, val)
             self.respond(200)
         except (KeyError, ValueError, NotImplementedError) as e:
-            self.respond(500, body='{}'.format(e))
+            self.respond(500, body=str(e))

--- a/mu/srv/server.py
+++ b/mu/srv/server.py
@@ -1,3 +1,4 @@
+import os
 import http.server
 import socketserver
 from functools import partial
@@ -21,6 +22,10 @@ class ThreadedServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 if __name__ == '__main__':
     address = ('', TCP_PORT)
     config = get_config()
+    # Set up canbus if vcan0
+    if config.canbus == 'vcan0':
+        os.system('sudo ip link add dev vcan0 type vcan')
+        os.system('sudo ip link set up vcan0')
     pm = ProjectManager(config=config)
     handler = partial(ReqHandler, pm)
     server = ThreadedServer(pm, address, handler)


### PR DESCRIPTION
This PR implements viewing and updating stores.

## Implementations
### Misc changes
- small improvements:
    - make all 'sensor' driver (adc, ads1259, ads1015, adt7476a) actually export their stores, so that when viewing stores you always have a complete picture
    - set up CAN in server.py, so if CAN isn't set up yet it'll work out of the box. it'll still fail (could be more graceful but whatever) if you try to run it with not vcan0 and you don't have the network set up.
    - make store.c not segfault if the update isn't expected. This could happen if a store isn't initialized and the store is updated. it's kind of an unnecessary check but I still want it because of the new ability to set stores from python.
    - req.py returns the request object instead of just the text, so that callers can check the status code. this is why there's a bunch of random changes in sims.py.
    - in decoder.py, factor out `store_from_name` and `store_from_enum` as other helper functions, since it's useful for api access to stores
    - factor out `sim_from_name` in pm.py since it's a useful helper function for api access to sims
### Viewing stores
- in args.py, set it so only the sim argument is required. if store type isn't specified, print all stores.
- set up stores.py as the container for store related functions
- just pretty print the json
- in board_sim.py, implement `stores_str_lookup` for looking up the store by the type name using a bit of protobuf reflectino magic
### Updating stores
- store type is a required arg, but key is still optional and is assumed 0 if not present
- Flow is as follows for muctl:
1. Grab the raw json from the `view` command
2. write it to a temp file
3. open vim on the temp file to allow for editing
4. read back the temp file into a string
5. use the `apply` method on the server with the updated store
- On the handler side, the apply method works by:
1. reading json from request body using the `Content-Length` header
2. getting a new appropriate store object from the `decoder` function
3. loading the json string into the store object using google's protobuf library. There's a weird intermediate step that seems necessary but I don't know why (loading it as a dict first, then parsing it into the actual message object)
4. get a full mask from a decoder helper function, because we want to apply all values. yes this can have unintended side effects if the stores update while the manual update is in progress, but I don't know how to deal with this
5. write the store and mask into the project
# Ok but that's kind of annoying, what about an easy way?
### SimIo / getters and setters
- a SimIo is a simple class that holds a getter and a setter, and has a name
- Any sim can register a new SimIo in `pm`
- This makes it really easy to set up new controls. This is meant for really simple things like toggling buttons or sensor values.
- idk it's pretty self explanatory, the commit is nicely separated from the rest of the stuff if you want to look at it individually