### PR TITLE
[SOFT-275] MCI Fan Control

### DIFF
--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -31,12 +31,19 @@
 
 // Fault types
 typedef enum {
-  MCI_FAN_CONTROL_DISCHARGE_OVERTEMP = 0,
-  MCI_FAN_CONTROL_PRECHARGE_OVERTEMP,
-  MCI_FAN_CONTROL_Q1_OVERTEMP,
-  MCI_FAN_CONTROL_Q3_OVERTEMP,
-  NUM_MCI_FAN_CONTROL_FAULTS,
-} MciFanControlFault;
+  MCI_THERM_DISCHARGE_OVERTEMP = 0,
+  MCI_THERM_PRECHARGE_OVERTEMP,
+  MCI_THERM_Q1_OVERTEMP,
+  MCI_THERM_Q3_OVERTEMP,
+  NUM_MCI_FAN_CONTROL_THERMS,
+} MciFanControlTherm;
+
+// Fan states
+typedef enum {
+  MCI_FAN_STATE_OFF = 0,
+  MCI_FAN_STATE_ON,
+  NUM_MCI_FAN_STATES,
+} MciFanState;
 
 // Called when a fault occurs/clears.
 typedef void (*MciFanControlFaultCallback)(uint8_t fault_bitset, void *context);
@@ -46,5 +53,13 @@ typedef struct {
   void *fault_context;
 } MciFanControlSettings;
 
+typedef struct {
+  MciFanControlFaultCallback fault_cb;
+  void *fault_context;
+  uint8_t fault_bitset;
+} MciFanControlStorage;
+
 // Initialize fan control and turn on the fan.
 StatusCode mci_fan_control_init(MciFanControlSettings *settings);
+
+StatusCode mci_fan_set_state(MciFanState state);

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -63,3 +63,6 @@ StatusCode mci_fan_control_init(MciFanControlSettings *settings);
 
 // Turn the fan on or off.
 StatusCode mci_fan_set_state(MciFanState state);
+
+// Returns the fault bitset.
+uint8_t mci_fan_get_fault_bitset(void);

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -1,0 +1,50 @@
+#pragma once
+// Fan control for MCI.  Currently hardcoded to turn the fan on to 100%
+// Requires GPIO to be initialized
+#include <inttypes.h>
+
+#include "status.h"
+
+// General pin definitions:
+#define MCI_FAN_EN_ADDR \
+  { GPIO_PORT_A, 0 }
+
+// Possibly unused
+#define MCI_FAN_PWM_ADDR \
+  { GPIO_PORT_A, 1 }
+
+// Connected to fan tachometers
+#define MCI_FAN_1_SENSE_ADDR \
+  { GPIO_PORT_A, 2 }
+#define MCI_FAN_2_SENSE_ADDR \
+  { GPIO_PORT_A, 3 }
+
+// Thermistors
+#define MCI_DISCHARGE_OVERTEMP_ADDR \
+  { GPIO_PORT_A, 4 }
+#define MCI_PRECHARGE_OVERTEMP_ADDR \
+  { GPIO_PORT_A, 5 }
+#define MCI_Q1_OVERTEMP_ADDR \
+  { GPIO_PORT_A, 6 }
+#define MCI_Q3_OVERTEMP_ADDR \
+  { GPIO_PORT_A, 7 }
+
+// Fault types
+typedef enum {
+  MCI_FAN_CONTROL_DISCHARGE_OVERTEMP = 0,
+  MCI_FAN_CONTROL_PRECHARGE_OVERTEMP,
+  MCI_FAN_CONTROL_Q1_OVERTEMP,
+  MCI_FAN_CONTROL_Q3_OVERTEMP,
+  NUM_MCI_FAN_CONTROL_FAULTS,
+} MciFanControlFault;
+
+// Called when a fault occurs/clears.
+typedef void (*MciFanControlFaultCallback)(uint8_t fault_bitset, void *context);
+
+typedef struct {
+  MciFanControlFaultCallback fault_cb;
+  void *fault_context;
+} MciFanControlSettings;
+
+// Initialize fan control and turn on the fan.
+StatusCode mci_fan_control_init(MciFanControlSettings *settings);

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -3,8 +3,8 @@
 // Requires GPIO, interrupts, and gpio interrupts to be initialized.
 #include <inttypes.h>
 
-#include "status.h"
 #include "gpio.h"
+#include "status.h"
 
 // General pin definitions:
 #define MCI_FAN_EN_ADDR \
@@ -35,6 +35,7 @@ typedef enum {
   NUM_MCI_FAN_CONTROL_THERMS,
 } MciFanControlTherm;
 
+// Expose addresses for testing
 extern const GpioAddress g_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS];
 
 // Fan states

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -1,9 +1,10 @@
 #pragma once
-// Fan control for MCI.  Currently hardcoded to turn the fan on to 100%
-// Requires GPIO to be initialized
+// Fan control for MCI based on thermistor status pins.
+// Requires GPIO, interrupts, and gpio interrupts to be initialized.
 #include <inttypes.h>
 
 #include "status.h"
+#include "gpio.h"
 
 // General pin definitions:
 #define MCI_FAN_EN_ADDR \
@@ -25,7 +26,7 @@
 #define MCI_Q3_OVERTEMP_ADDR \
   { GPIO_PORT_A, 7 }
 
-// Fault types
+// Thermistor indices
 typedef enum {
   MCI_THERM_DISCHARGE_OVERTEMP = 0,
   MCI_THERM_PRECHARGE_OVERTEMP,
@@ -33,6 +34,8 @@ typedef enum {
   MCI_THERM_Q3_OVERTEMP,
   NUM_MCI_FAN_CONTROL_THERMS,
 } MciFanControlTherm;
+
+extern const GpioAddress g_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS];
 
 // Fan states
 typedef enum {

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -9,10 +9,6 @@
 #define MCI_FAN_EN_ADDR \
   { GPIO_PORT_A, 0 }
 
-// Possibly unused
-#define MCI_FAN_PWM_ADDR \
-  { GPIO_PORT_A, 1 }
-
 // Connected to fan tachometers
 #define MCI_FAN_1_SENSE_ADDR \
   { GPIO_PORT_A, 2 }

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -38,7 +38,6 @@ typedef enum {
 // Expose addresses for testing
 extern const GpioAddress g_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS];
 
-// Fan states
 typedef enum {
   MCI_FAN_STATE_OFF = 0,
   MCI_FAN_STATE_ON,
@@ -59,7 +58,8 @@ typedef struct {
   uint8_t fault_bitset;
 } MciFanControlStorage;
 
-// Initialize fan control and turn on the fan.
+// Initialize fan control with the fan off.
 StatusCode mci_fan_control_init(MciFanControlSettings *settings);
 
+// Turn the fan on or off.
 StatusCode mci_fan_set_state(MciFanState state);

--- a/projects/mci/inc/mci_fan_control.h
+++ b/projects/mci/inc/mci_fan_control.h
@@ -1,6 +1,6 @@
 #pragma once
 // Fan control for MCI based on thermistor status pins.
-// Requires GPIO, interrupts, and gpio interrupts to be initialized.
+// Requires GPIO, interrupts, and GPIO interrupts to be initialized.
 #include <inttypes.h>
 
 #include "gpio.h"

--- a/projects/mci/rules.mk
+++ b/projects/mci/rules.mk
@@ -14,5 +14,5 @@ $(T)_EXCLUDE_TESTS := precharge
 $(T)_test_drive_fsm_MOCKS := get_precharge_state
 $(T)_test_cruise_rx_MOCKS := get_precharge_state
 $(T)_test_mci_output_MOCKS := mcp2515_tx drive_fsm_get_drive_state
-$(T)_test_mci_broadcast_MOCKS := 
+$(T)_test_mci_fan_control_MOCKS := gpio_get_state gpio_set_state
 endif

--- a/projects/mci/src/main.c
+++ b/projects/mci/src/main.c
@@ -12,6 +12,7 @@
 #include "drive_fsm.h"
 #include "mci_broadcast.h"
 #include "mci_events.h"
+#include "mci_fan_control.h"
 #include "mci_output.h"
 #include "motor_can.h"
 #include "motor_controller.h"
@@ -60,6 +61,14 @@ void prv_mci_storage_init(void *context) {
   mci_output_init(&s_mci_storage.mci_output_storage, &s_can_mcp2515);
 }
 
+void prv_fan_control_init(void) {
+  MciFanControlSettings fan_settings = {
+    .fault_cb = NULL,
+    .fault_context = NULL,
+  };
+  mci_fan_control_init(&fan_settings);
+}
+
 int main(void) {
   event_queue_init();
   interrupt_init();
@@ -70,6 +79,9 @@ int main(void) {
   prv_setup_system_can();
 
   prv_mci_storage_init(&s_mci_storage);
+
+  prv_fan_control_init();
+
   drive_fsm_init();
   Event e = { 0 };
   while (true) {

--- a/projects/mci/src/main.c
+++ b/projects/mci/src/main.c
@@ -25,7 +25,7 @@ static MotorControllerStorage s_mci_storage;
 
 static Mcp2515Storage s_can_mcp2515;
 
-void prv_setup_system_can() {
+static void prv_setup_system_can(void) {
   CanSettings can_settings = {
     .device_id = SYSTEM_CAN_DEVICE_MOTOR_CONTROLLER,
     .bitrate = CAN_HW_BITRATE_500KBPS,
@@ -42,7 +42,7 @@ void prv_setup_system_can() {
   cruise_rx_init();
 }
 
-void prv_mci_storage_init(void *context) {
+static void prv_mci_storage_init(void *context) {
   PrechargeControlSettings precharge_settings = {
     .precharge_control = { .port = GPIO_PORT_A, .pin = 9 },
     .precharge_monitor = { .port = GPIO_PORT_B, .pin = 0 },
@@ -61,7 +61,7 @@ void prv_mci_storage_init(void *context) {
   mci_output_init(&s_mci_storage.mci_output_storage, &s_can_mcp2515);
 }
 
-void prv_fan_control_init(void) {
+static void prv_fan_control_init(void) {
   MciFanControlSettings fan_settings = {
     .fault_cb = NULL,
     .fault_context = NULL,

--- a/projects/mci/src/mci_fan_control.c
+++ b/projects/mci/src/mci_fan_control.c
@@ -2,7 +2,6 @@
 
 #include "gpio.h"
 #include "gpio_it.h"
-#include "log.h"
 
 static MciFanControlStorage storage;
 
@@ -17,8 +16,7 @@ static const GpioAddress s_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS] = {
   [MCI_THERM_Q3_OVERTEMP] = MCI_Q3_OVERTEMP_ADDR,
 };
 
-// TODO(SOFT-275): figure out a more elegant way of doing this
-// (these need to be mapped somewhere in memory to pass them as context to the interrupt)
+// Store thermistor indices to pass as context to interrupt callback
 static const uint8_t s_therm_indices[NUM_MCI_FAN_CONTROL_THERMS] = {
   [MCI_THERM_DISCHARGE_OVERTEMP] = MCI_THERM_DISCHARGE_OVERTEMP,
   [MCI_THERM_PRECHARGE_OVERTEMP] = MCI_THERM_PRECHARGE_OVERTEMP,
@@ -30,23 +28,27 @@ static const uint8_t s_therm_indices[NUM_MCI_FAN_CONTROL_THERMS] = {
 static void prv_handle_therm_it(const GpioAddress *address, void *context) {
   // Context holds the index of the fault pin
   uint8_t index = *((uint8_t *)(context));
-  LOG_DEBUG("Therm it fired for index %d pin %d\n", index, address->pin);
 
   GpioState state = NUM_GPIO_STATES;
   gpio_get_state(&s_therm_addrs[index], &state);
 
   if (state == GPIO_STATE_HIGH) {
     // Set fault
-    LOG_DEBUG("Setting fault\n");
     storage.fault_bitset |= 1 << index;
   } else {
     // Clear fault
-    LOG_DEBUG("clearing fault\n");
     storage.fault_bitset &= ~(1 << index);
   }
 
+  // If there's an active fault, fan on.  Otherwise, turn off.
+  if (storage.fault_bitset == 0) {
+    mci_fan_set_state(MCI_FAN_STATE_OFF);
+  } else {
+    mci_fan_set_state(MCI_FAN_STATE_ON);
+  }
+
+  // Only call the fault callback if it exists
   if (storage.fault_cb) {
-    LOG_DEBUG("Calling cb with fault bitset %d\n", storage.fault_bitset);
     storage.fault_cb(storage.fault_bitset, storage.fault_context);
   }
 }
@@ -64,22 +66,21 @@ static StatusCode prv_configure_therm_it(GpioAddress *address, uint8_t pin_idx) 
     .priority = INTERRUPT_PRIORITY_NORMAL,
   };
 
-  LOG_DEBUG("registering with index %d\n", pin_idx);
   return gpio_it_register_interrupt(address, &it_settings, INTERRUPT_EDGE_RISING_FALLING,
                                     prv_handle_therm_it, &s_therm_indices[pin_idx]);
 }
 
 StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
-  // Currently, just set fan to 100%
+  // Fan initially off
   GpioSettings pin_settings = {
     .direction = GPIO_DIR_OUT,
     .alt_function = GPIO_ALTFN_NONE,
-    .state = GPIO_STATE_HIGH,
+    .state = GPIO_STATE_LOW,
     .resistor = GPIO_RES_NONE,
   };
 
   status_ok_or_return(gpio_init_pin(&s_en_addr, &pin_settings));
-  status_ok_or_return(gpio_set_state(&s_en_addr, GPIO_STATE_HIGH));
+  status_ok_or_return(mci_fan_set_state(MCI_FAN_STATE_OFF));
 
   storage.fault_cb = settings->fault_cb;
   storage.fault_context = settings->fault_context;

--- a/projects/mci/src/mci_fan_control.c
+++ b/projects/mci/src/mci_fan_control.c
@@ -3,7 +3,7 @@
 #include "gpio.h"
 #include "gpio_it.h"
 
-static MciFanControlStorage s_storage;
+static MciFanControlStorage s_storage = { 0 };
 
 // Enable pin
 static const GpioAddress s_en_addr = MCI_FAN_EN_ADDR;
@@ -48,10 +48,12 @@ static void prv_handle_therm_it(const GpioAddress *address, void *context) {
 
 // Set up a thermistor pin for interrupts.
 static StatusCode prv_configure_therm_it(GpioAddress *address, uint8_t pin_idx) {
-  const GpioSettings settings = { .direction = GPIO_DIR_IN,
-                                  .state = GPIO_STATE_LOW,
-                                  .alt_function = GPIO_ALTFN_NONE,
-                                  .resistor = GPIO_RES_NONE };
+  const GpioSettings settings = {
+    .direction = GPIO_DIR_IN,
+    .state = GPIO_STATE_LOW,
+    .alt_function = GPIO_ALTFN_NONE,
+    .resistor = GPIO_RES_NONE,
+  };
   status_ok_or_return(gpio_init_pin(address, &settings));
 
   const InterruptSettings it_settings = {
@@ -87,7 +89,7 @@ StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
 }
 
 StatusCode mci_fan_set_state(MciFanState state) {
-  GpioState gpio_state = (state == MCI_FAN_STATE_ON);
+  GpioState gpio_state = (state == MCI_FAN_STATE_ON) ? GPIO_STATE_HIGH : GPIO_STATE_LOW;
   return gpio_set_state(&s_en_addr, gpio_state);
 }
 

--- a/projects/mci/src/mci_fan_control.c
+++ b/projects/mci/src/mci_fan_control.c
@@ -1,0 +1,22 @@
+#include "mci_fan_control.h"
+
+#include "gpio.h"
+
+// Stores fault types
+static uint8_t fault_bitset;
+
+StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
+  // Currently, just set fan to 100%
+  GpioSettings pin_settings = {
+    .direction = GPIO_DIR_OUT,
+    .alt_function = GPIO_ALTFN_NONE,
+    .state = GPIO_STATE_HIGH,
+    .resistor = GPIO_RES_NONE,
+  };
+  GpioAddress en_addr = MCI_FAN_EN_ADDR;
+
+  status_ok_or_return(gpio_init_pin(&en_addr, &pin_settings));
+  return gpio_set_state(&en_addr, GPIO_STATE_HIGH);
+  // TODO(SOFT-275): set PWM to 100% if needed
+  // TODO(SOFT-275): interrupts on thermistor overtemps if needed
+}

--- a/projects/mci/src/mci_fan_control.c
+++ b/projects/mci/src/mci_fan_control.c
@@ -9,14 +9,14 @@ static MciFanControlStorage storage;
 static const GpioAddress s_en_addr = MCI_FAN_EN_ADDR;
 
 // Thermistor pins
-static const GpioAddress s_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS] = {
+const GpioAddress g_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS] = {
   [MCI_THERM_DISCHARGE_OVERTEMP] = MCI_DISCHARGE_OVERTEMP_ADDR,
   [MCI_THERM_PRECHARGE_OVERTEMP] = MCI_PRECHARGE_OVERTEMP_ADDR,
   [MCI_THERM_Q1_OVERTEMP] = MCI_Q1_OVERTEMP_ADDR,
   [MCI_THERM_Q3_OVERTEMP] = MCI_Q3_OVERTEMP_ADDR,
 };
 
-// Store thermistor indices to pass as context to interrupt callback
+// Store fault indices to pass as context to interrupt callback
 static const uint8_t s_therm_indices[NUM_MCI_FAN_CONTROL_THERMS] = {
   [MCI_THERM_DISCHARGE_OVERTEMP] = MCI_THERM_DISCHARGE_OVERTEMP,
   [MCI_THERM_PRECHARGE_OVERTEMP] = MCI_THERM_PRECHARGE_OVERTEMP,
@@ -30,7 +30,7 @@ static void prv_handle_therm_it(const GpioAddress *address, void *context) {
   uint8_t index = *((uint8_t *)(context));
 
   GpioState state = NUM_GPIO_STATES;
-  gpio_get_state(&s_therm_addrs[index], &state);
+  gpio_get_state(&g_therm_addrs[index], &state);
 
   if (state == GPIO_STATE_HIGH) {
     // Set fault
@@ -53,7 +53,7 @@ static void prv_handle_therm_it(const GpioAddress *address, void *context) {
   }
 }
 
-// Set up a thermistor pin for interrupts
+// Set up a thermistor pin for interrupts.
 static StatusCode prv_configure_therm_it(GpioAddress *address, uint8_t pin_idx) {
   const GpioSettings settings = { .direction = GPIO_DIR_IN,
                                   .state = GPIO_STATE_LOW,
@@ -85,9 +85,9 @@ StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
   storage.fault_cb = settings->fault_cb;
   storage.fault_context = settings->fault_context;
 
-  // Configure thermistor interrupts
+  // Configure all thermistor pins
   for (uint8_t i = 0; i < NUM_MCI_FAN_CONTROL_THERMS; i++) {
-    status_ok_or_return(prv_configure_therm_it(&s_therm_addrs[i], i));
+    status_ok_or_return(prv_configure_therm_it(&g_therm_addrs[i], i));
   }
 
   return STATUS_CODE_OK;

--- a/projects/mci/src/mci_fan_control.c
+++ b/projects/mci/src/mci_fan_control.c
@@ -1,9 +1,63 @@
 #include "mci_fan_control.h"
 
 #include "gpio.h"
+#include "gpio_it.h"
+#include "log.h"
 
-// Stores fault types
-static uint8_t fault_bitset;
+static MciFanControlStorage storage;
+
+// Enable pin
+static const GpioAddress s_en_addr = MCI_FAN_EN_ADDR;
+
+// Thermistor pins
+static const GpioAddress s_therm_addrs[NUM_MCI_FAN_CONTROL_THERMS] = {
+  [MCI_THERM_DISCHARGE_OVERTEMP] = MCI_DISCHARGE_OVERTEMP_ADDR,
+  [MCI_THERM_PRECHARGE_OVERTEMP] = MCI_PRECHARGE_OVERTEMP_ADDR,
+  [MCI_THERM_Q1_OVERTEMP] = MCI_Q1_OVERTEMP_ADDR,
+  [MCI_THERM_Q3_OVERTEMP] = MCI_Q3_OVERTEMP_ADDR,
+};
+
+// Handle a fault interrupt.
+static void prv_handle_therm_it(const GpioAddress *address, void *context) {
+  // Context holds the index of the fault pin
+  uint8_t index = *((uint8_t *)(context));
+  LOG_DEBUG("Therm it fired for index %d\n", index);
+
+  GpioState state = NUM_GPIO_STATES;
+  gpio_get_state(&s_therm_addrs[index], &state);
+
+  if (state == GPIO_STATE_HIGH) {
+    // Set fault
+    LOG_DEBUG("Setting fault\n");
+    storage.fault_bitset |= 1 << index;
+  } else {
+    // Clear fault
+    LOG_DEBUG("clearing fault\n");
+    storage.fault_bitset &= ~(1 << index);
+  }
+
+  if (storage.fault_cb) {
+    LOG_DEBUG("Calling cb with fault bitset %d\n", storage.fault_bitset);
+    storage.fault_cb(storage.fault_bitset, storage.fault_context);
+  }
+}
+
+// Set up a thermistor pin for interrupts
+static StatusCode prv_configure_therm_it(GpioAddress *address, uint8_t pin_idx) {
+  const GpioSettings settings = { .direction = GPIO_DIR_IN,
+                                  .state = GPIO_STATE_LOW,
+                                  .alt_function = GPIO_ALTFN_NONE,
+                                  .resistor = GPIO_RES_NONE };
+  status_ok_or_return(gpio_init_pin(address, &settings));
+
+  const InterruptSettings it_settings = {
+    .type = INTERRUPT_TYPE_INTERRUPT,
+    .priority = INTERRUPT_PRIORITY_NORMAL,
+  };
+
+  return gpio_it_register_interrupt(address, &it_settings, INTERRUPT_EDGE_RISING_FALLING,
+                                    prv_handle_therm_it, &pin_idx);
+}
 
 StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
   // Currently, just set fan to 100%
@@ -13,10 +67,22 @@ StatusCode mci_fan_control_init(MciFanControlSettings *settings) {
     .state = GPIO_STATE_HIGH,
     .resistor = GPIO_RES_NONE,
   };
-  GpioAddress en_addr = MCI_FAN_EN_ADDR;
 
-  status_ok_or_return(gpio_init_pin(&en_addr, &pin_settings));
-  return gpio_set_state(&en_addr, GPIO_STATE_HIGH);
-  // TODO(SOFT-275): set PWM to 100% if needed
-  // TODO(SOFT-275): interrupts on thermistor overtemps if needed
+  status_ok_or_return(gpio_init_pin(&s_en_addr, &pin_settings));
+  status_ok_or_return(gpio_set_state(&s_en_addr, GPIO_STATE_HIGH));
+
+  storage.fault_cb = settings->fault_cb;
+  storage.fault_context = settings->fault_context;
+
+  // Configure thermistor interrupts
+  for (uint8_t i = 0; i < NUM_MCI_FAN_CONTROL_THERMS; i++) {
+    status_ok_or_return(prv_configure_therm_it(&s_therm_addrs[i], i));
+  }
+
+  return STATUS_CODE_OK;
+}
+
+StatusCode mci_fan_set_state(MciFanState state) {
+  GpioState gpio_state = (state == MCI_FAN_STATE_ON);
+  return gpio_set_state(&s_en_addr, gpio_state);
 }

--- a/projects/mci/test/test_mci_fan_control.c
+++ b/projects/mci/test/test_mci_fan_control.c
@@ -15,8 +15,8 @@ static void prv_init_fan(void) {
 }
 
 // Used to make sure the fault callback is working as expected
-static volatile uint16_t s_times_cb_called;
-static volatile uint8_t s_fault_bitset;
+static uint16_t s_times_cb_called = 0;
+static uint8_t s_fault_bitset = 0;
 static void prv_test_fault_cb(uint8_t fault_bitset, void *context) {
   s_times_cb_called++;
   s_fault_bitset = fault_bitset;
@@ -31,14 +31,14 @@ static void prv_init_fan_with_cb(void) {
   TEST_ASSERT_OK(mci_fan_control_init(&settings));
 }
 
-static GpioState s_test_get_state;
+static GpioState s_test_get_state = GPIO_STATE_LOW;
 StatusCode TEST_MOCK(gpio_get_state)(const GpioAddress *address, GpioState *input_state) {
   *input_state = s_test_get_state;
   return STATUS_CODE_OK;
 }
 
 // Only used to check EN pin
-static volatile GpioState s_test_en_set_state;
+static GpioState s_test_en_set_state = GPIO_STATE_LOW;
 static const GpioAddress s_en_pin_addr = MCI_FAN_EN_ADDR;
 StatusCode TEST_MOCK(gpio_set_state)(const GpioAddress *address, GpioState state) {
   if (address->pin == s_en_pin_addr.pin) {
@@ -79,6 +79,8 @@ void setup_test(void) {
 void teardown_test(void) {
   s_times_cb_called = 0;
   s_fault_bitset = 0;
+  s_test_get_state = GPIO_STATE_LOW;
+  s_test_en_set_state = GPIO_STATE_LOW;
 }
 
 // Confirm that fan control initializes as expected.

--- a/projects/mci/test/test_mci_fan_control.c
+++ b/projects/mci/test/test_mci_fan_control.c
@@ -3,8 +3,8 @@
 #include "gpio.h"
 #include "gpio_it.h"
 #include "interrupt.h"
-#include "ms_test_helpers.h"
 #include "log.h"
+#include "ms_test_helpers.h"
 
 // Initialize fan control with no callbacks.
 static void prv_init_fan(void) {
@@ -91,17 +91,16 @@ void test_general_fault(void) {
   TEST_ASSERT_EQUAL(0, s_fault_bitset);
 
   // Q1 overtemp
-  GpioAddress test_pin = MCI_Q1_OVERTEMP_ADDR;
   s_test_get_state = GPIO_STATE_HIGH;
-  gpio_it_trigger_interrupt(&test_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q1_OVERTEMP]);
   TEST_ASSERT_EQUAL(1, s_times_cb_called);
-  TEST_ASSERT_EQUAL((1 << MCI_FAULT_Q1_OVERTEMP), s_fault_bitset);
+  TEST_ASSERT_EQUAL((1 << MCI_THERM_Q1_OVERTEMP), s_fault_bitset);
   // Fan should now be on
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Clear fault
   s_test_get_state = GPIO_STATE_LOW;
-  gpio_it_trigger_interrupt(&test_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q1_OVERTEMP]);
   TEST_ASSERT_EQUAL(2, s_times_cb_called);
   TEST_ASSERT_EQUAL(0, s_fault_bitset);
   // Fan should now be off
@@ -116,9 +115,8 @@ void test_fault_no_cb(void) {
   TEST_ASSERT_EQUAL(0, s_fault_bitset);
 
   // Q1 overtemp
-  GpioAddress test_pin = MCI_Q1_OVERTEMP_ADDR;
   s_test_get_state = GPIO_STATE_HIGH;
-  gpio_it_trigger_interrupt(&test_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q1_OVERTEMP]);
 
   // Callback shouldn't have been called
   TEST_ASSERT_EQUAL(0, s_times_cb_called);
@@ -141,8 +139,7 @@ void test_all_faults(void) {
   s_test_get_state = GPIO_STATE_HIGH;
 
   // Q1 overtemp
-  GpioAddress test_q1_pin = MCI_Q1_OVERTEMP_ADDR;
-  gpio_it_trigger_interrupt(&test_q1_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q1_OVERTEMP]);
   TEST_ASSERT_EQUAL(1, s_times_cb_called);
   test_expected_bitset |= (1 << MCI_THERM_Q1_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
@@ -151,18 +148,16 @@ void test_all_faults(void) {
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Add Q3 overtemp
-  GpioAddress test_q3_pin = MCI_Q1_OVERTEMP_ADDR;
-  gpio_it_trigger_interrupt(&test_q3_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q3_OVERTEMP]);
   TEST_ASSERT_EQUAL(2, s_times_cb_called);
-  test_expected_bitset |= (1 << MCI_THERM_Q1_OVERTEMP);
+  test_expected_bitset |= (1 << MCI_THERM_Q3_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
 
   // Fan should still be on
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Add discharge overtemp
-  GpioAddress test_discharge_pin = MCI_DISCHARGE_OVERTEMP_ADDR;
-  gpio_it_trigger_interrupt(&test_discharge_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_DISCHARGE_OVERTEMP]);
   TEST_ASSERT_EQUAL(3, s_times_cb_called);
   test_expected_bitset |= (1 << MCI_THERM_DISCHARGE_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
@@ -171,8 +166,7 @@ void test_all_faults(void) {
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Add precharge overtemp
-  GpioAddress test_precharge_pin = MCI_PRECHARGE_OVERTEMP_ADDR;
-  gpio_it_trigger_interrupt(&test_precharge_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_PRECHARGE_OVERTEMP]);
   TEST_ASSERT_EQUAL(4, s_times_cb_called);
   test_expected_bitset |= (1 << MCI_THERM_PRECHARGE_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
@@ -184,7 +178,7 @@ void test_all_faults(void) {
   s_test_get_state = GPIO_STATE_LOW;
 
   // Clear Q1 overtemp
-  gpio_it_trigger_interrupt(&test_q1_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q1_OVERTEMP]);
   TEST_ASSERT_EQUAL(5, s_times_cb_called);
   test_expected_bitset &= ~(1 << MCI_THERM_Q1_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
@@ -193,16 +187,16 @@ void test_all_faults(void) {
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Clear Q3 overtemp
-  gpio_it_trigger_interrupt(&test_q3_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_Q3_OVERTEMP]);
   TEST_ASSERT_EQUAL(6, s_times_cb_called);
-  test_expected_bitset &= ~(1 << MCI_THERM_Q1_OVERTEMP);
+  test_expected_bitset &= ~(1 << MCI_THERM_Q3_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
 
   // Fan should still be on
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Clear discharge overtemp
-  gpio_it_trigger_interrupt(&test_discharge_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_DISCHARGE_OVERTEMP]);
   TEST_ASSERT_EQUAL(7, s_times_cb_called);
   test_expected_bitset &= ~(1 << MCI_THERM_DISCHARGE_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);
@@ -211,7 +205,7 @@ void test_all_faults(void) {
   TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 
   // Clear precharge overtemp
-  gpio_it_trigger_interrupt(&test_precharge_pin);
+  gpio_it_trigger_interrupt(&g_therm_addrs[MCI_THERM_PRECHARGE_OVERTEMP]);
   TEST_ASSERT_EQUAL(8, s_times_cb_called);
   test_expected_bitset &= ~(1 << MCI_THERM_PRECHARGE_OVERTEMP);
   TEST_ASSERT_EQUAL(test_expected_bitset, s_fault_bitset);

--- a/projects/mci/test/test_mci_fan_control.c
+++ b/projects/mci/test/test_mci_fan_control.c
@@ -5,14 +5,6 @@
 #include "interrupt.h"
 #include "ms_test_helpers.h"
 
-void setup_test(void) {
-  gpio_init();
-  interrupt_init();
-  gpio_it_init();
-}
-
-void teardown_test(void) {}
-
 // Initialize fan control with no callbacks.
 static void prv_init_fan(void) {
   MciFanControlSettings settings = {
@@ -39,20 +31,36 @@ static void prv_init_fan_with_cb(void) {
   TEST_ASSERT_OK(mci_fan_control_init(&settings));
 }
 
-// Confirm that the fan state is as expected.
-static void prv_assert_fan_state(GpioState state) {
-  GpioAddress test_en_addr = MCI_FAN_EN_ADDR;
-  GpioState test_en_state = GPIO_STATE_LOW;
-  TEST_ASSERT_OK(gpio_get_state(&test_en_addr, &test_en_state));
-  TEST_ASSERT_EQUAL(state, test_en_state);
+static GpioState s_test_get_state;
+StatusCode TEST_MOCK(gpio_get_state)(const GpioAddress *address, GpioState *input_state) {
+  *input_state = s_test_get_state;
+  return STATUS_CODE_OK;
 }
+
+// Only used to check EN pin
+static GpioState s_test_en_set_state;
+static const GpioAddress s_en_pin_addr = MCI_FAN_EN_ADDR;
+StatusCode TEST_MOCK(gpio_set_state)(const GpioAddress *address, GpioState state) {
+  if (address->pin == s_en_pin_addr.pin) {
+    s_test_en_set_state = state;
+  }
+  return STATUS_CODE_OK;
+}
+
+void setup_test(void) {
+  gpio_init();
+  interrupt_init();
+  gpio_it_init();
+}
+
+void teardown_test(void) {}
 
 // Confirm that fan control initializes as expected.
 void test_init(void) {
   prv_init_fan();
 
   // Pin should be high after initialization
-  prv_assert_fan_state(GPIO_STATE_HIGH);
+  TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 }
 
 // Confirm that the fan can be turned on and off.
@@ -60,16 +68,17 @@ void test_set_state(void) {
   prv_init_fan();
 
   mci_fan_set_state(MCI_FAN_STATE_OFF);
-  prv_assert_fan_state(GPIO_STATE_LOW);
+  TEST_ASSERT_EQUAL(GPIO_STATE_LOW, s_test_en_set_state);
 
   mci_fan_set_state(MCI_FAN_STATE_ON);
-  prv_assert_fan_state(GPIO_STATE_HIGH);
+  TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, s_test_en_set_state);
 }
 
 // Initialize with a callback.
 void test_init_with_cb(void) {
   prv_init_fan_with_cb();
 }
+
 // Confirm that general fault handling procedures work as expected
 void test_general_fault(void) {
   prv_init_fan_with_cb();
@@ -79,7 +88,7 @@ void test_general_fault(void) {
 
   // Q1 overtemp
   GpioAddress test_pin = MCI_Q1_OVERTEMP_ADDR;
-  gpio_set_state(&test_pin, GPIO_STATE_HIGH);
+  s_test_get_state = GPIO_STATE_HIGH;
   gpio_it_trigger_interrupt(&test_pin);
   TEST_ASSERT_EQUAL(1, s_times_cb_called);
   TEST_ASSERT_EQUAL((1 << MCI_THERM_Q1_OVERTEMP), s_fault_bitset);

--- a/projects/mci/test/test_mci_fan_control.c
+++ b/projects/mci/test/test_mci_fan_control.c
@@ -1,24 +1,86 @@
 #include "mci_fan_control.h"
 
 #include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"
 #include "ms_test_helpers.h"
 
 void setup_test(void) {
   gpio_init();
+  interrupt_init();
+  gpio_it_init();
 }
 
 void teardown_test(void) {}
 
-void test_init(void) {
+// Initialize fan control with no callbacks.
+static void prv_init_fan(void) {
   MciFanControlSettings settings = {
     .fault_cb = NULL,
     .fault_context = NULL,
   };
   TEST_ASSERT_OK(mci_fan_control_init(&settings));
+}
 
-  // Pin should be high after initialization
+// Used to make sure the fault callback is working as expected
+static uint16_t s_times_cb_called;
+static uint8_t s_fault_bitset;
+static void prv_test_fault_cb(uint8_t fault_bitset, void *context) {
+  s_times_cb_called++;
+  s_fault_bitset = fault_bitset;
+}
+
+// Initialize fan control with prv_test_fault_cb
+static void prv_init_fan_with_cb(void) {
+  MciFanControlSettings settings = {
+    .fault_cb = prv_test_fault_cb,
+    .fault_context = NULL,
+  };
+  TEST_ASSERT_OK(mci_fan_control_init(&settings));
+}
+
+// Confirm that the fan state is as expected.
+static void prv_assert_fan_state(GpioState state) {
   GpioAddress test_en_addr = MCI_FAN_EN_ADDR;
   GpioState test_en_state = GPIO_STATE_LOW;
   TEST_ASSERT_OK(gpio_get_state(&test_en_addr, &test_en_state));
-  TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, test_en_state);
+  TEST_ASSERT_EQUAL(state, test_en_state);
+}
+
+// Confirm that fan control initializes as expected.
+void test_init(void) {
+  prv_init_fan();
+
+  // Pin should be high after initialization
+  prv_assert_fan_state(GPIO_STATE_HIGH);
+}
+
+// Confirm that the fan can be turned on and off.
+void test_set_state(void) {
+  prv_init_fan();
+
+  mci_fan_set_state(MCI_FAN_STATE_OFF);
+  prv_assert_fan_state(GPIO_STATE_LOW);
+
+  mci_fan_set_state(MCI_FAN_STATE_ON);
+  prv_assert_fan_state(GPIO_STATE_HIGH);
+}
+
+// Initialize with a callback.
+void test_init_with_cb(void) {
+  prv_init_fan_with_cb();
+}
+// Confirm that general fault handling procedures work as expected
+void test_general_fault(void) {
+  prv_init_fan_with_cb();
+
+  TEST_ASSERT_EQUAL(0, s_times_cb_called);
+  TEST_ASSERT_EQUAL(0, s_fault_bitset);
+
+  // Q1 overtemp
+  GpioAddress test_pin = MCI_Q1_OVERTEMP_ADDR;
+  gpio_set_state(&test_pin, GPIO_STATE_HIGH);
+  gpio_it_trigger_interrupt(&test_pin);
+  TEST_ASSERT_EQUAL(1, s_times_cb_called);
+  TEST_ASSERT_EQUAL((1 << MCI_THERM_Q1_OVERTEMP), s_fault_bitset);
 }

--- a/projects/mci/test/test_mci_fan_control.c
+++ b/projects/mci/test/test_mci_fan_control.c
@@ -1,0 +1,24 @@
+#include "mci_fan_control.h"
+
+#include "gpio.h"
+#include "ms_test_helpers.h"
+
+void setup_test(void) {
+  gpio_init();
+}
+
+void teardown_test(void) {}
+
+void test_init(void) {
+  MciFanControlSettings settings = {
+    .fault_cb = NULL,
+    .fault_context = NULL,
+  };
+  TEST_ASSERT_OK(mci_fan_control_init(&settings));
+
+  // Pin should be high after initialization
+  GpioAddress test_en_addr = MCI_FAN_EN_ADDR;
+  GpioState test_en_state = GPIO_STATE_LOW;
+  TEST_ASSERT_OK(gpio_get_state(&test_en_addr, &test_en_state));
+  TEST_ASSERT_EQUAL(GPIO_STATE_HIGH, test_en_state);
+}


### PR DESCRIPTION
Fan control module for MCI.  The way this works is pretty simple -- there's a single pin, `MCI_FAN_EN_ADDR`, that is used to turn on/off the fans.  This is abstracted by `mci_fan_set_state()`.  Hardware wants the fan state based on the temperature measurements from the motor controllers, so that's for a future ticket.

There are also four pins that go high when the corresponding thermistor on the MCI board hits a certain threshold.  Eventually we should log these over CAN using `SYSTEM_CAN_MESSAGE_MOTOR_STATUS`, but for now we just track their status in a fault bitset that can be exported using `mci_fan_get_fault_bitset()`.  A fault callback can also be passed in on initialization, and will be called each time the fault bitset updates.

The test sequence for this is pretty short, as the module itself is quite simple.