### PR TITLE
[SOFT-539] Fix CI certificate issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
           ln -sf `which clang-5.0` ~/.local/bin/clang
           ln -sf `which clang-format-5.0` ~/.local/bin/clang-format
 
-      - uses: fiam/arm-none-eabi-gcc@v1
+      - uses: fiam/arm-none-eabi-gcc@v1.0.4
         with:
           release: '6-2017-q2'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,9 @@ jobs:
         run: |
           wget -nv $GCC_URL
           mkdir -p $GCC_PATH
-          tar -xjvf $GCC_ARCHIVE_PATH
+          tar -xjf $GCC_ARCHIVE_PATH
+          pwd
+          ls
           ls ${HOME}
           ls ${HOME}/${GCC_PATH}
           echo "${HOME}/${GCC_PATH}/bin" >> $GITHUB_PATH

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,9 +43,16 @@ jobs:
           ln -sf `which clang-5.0` ~/.local/bin/clang
           ln -sf `which clang-format-5.0` ~/.local/bin/clang-format
 
-      - uses: fiam/arm-none-eabi-gcc@v1.0.4
-        with:
-          release: '6-2017-q2'
+      - name: Install STM32 toolchain
+        env:
+          GCC_PATH: gcc-arm-none-eabi-6-2017-q2-update
+          GCC_ARCHIVE_PATH: gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+          GCC_URL: https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+        run: |
+          wget -nv $GCC_URL
+          mkdir -p $GCC_PATH
+          tar -xzf $GCC_ARCHIVE_PATH
+          echo "${HOME}/${GCC_PATH}/bin" >> $GITHUB_PATH
 
       - name: Install GNU Make 4.1
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           wget -nv $GCC_URL
           mkdir -p $GCC_PATH
-          tar -xzf $GCC_ARCHIVE_PATH
+          tar -xjf $GCC_ARCHIVE_PATH
           echo "${HOME}/${GCC_PATH}/bin" >> $GITHUB_PATH
 
       - name: Install GNU Make 4.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,13 +49,10 @@ jobs:
           GCC_ARCHIVE_PATH: gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
           GCC_URL: https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
         run: |
+          cd ${HOME}
           wget -nv $GCC_URL
           mkdir -p $GCC_PATH
           tar -xjf $GCC_ARCHIVE_PATH
-          pwd
-          ls
-          ls ${HOME}
-          ls ${HOME}/${GCC_PATH}
           echo "${HOME}/${GCC_PATH}/bin" >> $GITHUB_PATH
 
       - name: Install GNU Make 4.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,9 @@ jobs:
         run: |
           wget -nv $GCC_URL
           mkdir -p $GCC_PATH
-          tar -xjf $GCC_ARCHIVE_PATH
+          tar -xjvf $GCC_ARCHIVE_PATH
+          ls ${HOME}
+          ls ${HOME}/${GCC_PATH}
           echo "${HOME}/${GCC_PATH}/bin" >> $GITHUB_PATH
 
       - name: Install GNU Make 4.1

--- a/libraries/nanopb/LICENSE
+++ b/libraries/nanopb/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2011 Petteri Aimonen <jpa at nanopb.mail.kapsi.fi>
+
+This software is provided 'as-is', without any express or 
+implied warranty. In no event will the authors be held liable 
+for any damages arising from the use of this software.
+
+Permission is granted to anyone to use this software for any 
+purpose, including commercial applications, and to alter it and 
+redistribute it freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you 
+   must not claim that you wrote the original software. If you use 
+   this software in a product, an acknowledgment in the product 
+   documentation would be appreciated but is not required.
+
+2. Altered source versions must be plainly marked as such, and 
+   must not be misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source 
+   distribution.

--- a/libraries/nanopb/README.md
+++ b/libraries/nanopb/README.md
@@ -1,6 +1,4 @@
-This library contains the .h and .c files for nanopb
-
-https://github.com/nanopb
-
 # nanopb
 
+This library contains the .h and .c files for compiling projects using
+[nanopb](https://github.com/nanopb), originally written by Petteri Aimonen.


### PR DESCRIPTION
For some reason, the fiam/arm-none-eabi-gcc action in CI was failing with a certificate issue. To fix it, we just install the arm-none-eabi toolchain ourselves instead of using the third-party action.

Also, added a copy of the nanopb license to libraries/nanopb so we don't violate any license terms.