### PR TITLE
[SOFT-151] Fix scaling in ads1259 smoketest

### DIFF
--- a/projects/smoke_ads1259/src/main.c
+++ b/projects/smoke_ads1259/src/main.c
@@ -8,9 +8,9 @@
 #include "soft_timer.h"
 
 // change this number to read for x cycles, 0 for infinite
-#define READ_CYCLE_NUM 2
+#define READ_CYCLE_NUM 0
 // change this number to read x times in a cycle
-#define READ_CYCLE_SIZE 3
+#define READ_CYCLE_SIZE 1
 
 // slightly larger than conversion time of adc
 #define CONVERSION_TIME_MS 18
@@ -34,7 +34,7 @@ static void prv_periodic_read(SoftTimerId id, void *context) {
               (int)(EXTERNAL_VREF_V * 1000));
     ads1259_get_conversion_data(&s_storage);
     queue[s_index] = s_storage.reading;
-    LOG_DEBUG("%d mV\n", (uint16_t)(s_storage.reading * 1000));
+    LOG_DEBUG("%d mV\n", (uint16_t)(s_storage.reading * 100 * 1000));
     s_index++;
     soft_timer_start_millis(CONVERSION_TIME_MS, prv_periodic_read, queue, NULL);
   } else {


### PR DESCRIPTION
It's just a bit nicer this way.  (The 100* scaling factor is actually an good fix, the read cycle sizes just make more sense this way)