### PR TITLE
[SOFT-413] Fix sizes in `make temp-bootloader-write`

### DIFF
--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -91,10 +91,10 @@ gdb: $(TARGET_BINARY)
 
 # ABSOLUTELY, COMPLETELY, ENTIRELY TEMPORARY: build + flash the bootloader preloaded with an application
 # ONCE IT IS NO LONGER NECESSARY, REMOVE THIS AND ALL ITS REFERENCES
-# application code starts at 16K (bootloader) + 2K (config page 1) + 2K (config page 2) = 20480
+# application code starts at 32K (bootloader) + 2K (config page 1) + 2K (config page 2) = 36864
 temp-bootloader-write: $(TARGET_BINARY:$(PLATFORM_EXT)=.bin) $(BIN_DIR)/bootloader.bin
 	@cp $(BIN_DIR)/bootloader.bin $(BIN_DIR)/bootloader-ready.bin
-	@dd if=$(TARGET_BINARY:$(PLATFORM_EXT)=.bin) of=$(BIN_DIR)/bootloader-ready.bin bs=1 seek=20480
+	@dd if=$(TARGET_BINARY:$(PLATFORM_EXT)=.bin) of=$(BIN_DIR)/bootloader-ready.bin bs=1 seek=36864
 	@$(OPENOCD) $(OPENOCD_CFG) -c "stm_flash $(BIN_DIR)/bootloader-ready.bin" -c shutdown
 
 define session_wrapper


### PR DESCRIPTION
We updated the bootloader size from 16K to 32K at some point but neglected to update `make temp-bootloader-write`, which would cause impossible-to-debug linker script issues. Updated the size to fix it.

@mitchellostler, @vaaranan-y, and anyone else testing bootloader onsite this weekend: you'll have to make sure this PR is on your branch before testing. Otherwise, you should be able to do `make temp-bootloader-write PROJECT=leds` to flash the `leds` project on top of the bootloader (although the config will *not* be populated). Also, if you're testing the flash-application-code operation, you might have to dig into the linker scripts to generate a properly offsetted application-only binary (though it *should* just be as simple as using the .bin file for the particular application generated during `make temp-bootloader-write`).