### PR TITLE
[SOFT-999] Complete fw103

### DIFF
--- a/projects/fw_103/README.md
+++ b/projects/fw_103/README.md
@@ -1,0 +1,16 @@
+<!--
+    General guidelines
+    These are just guidelines, not strict rules - document however seems best.
+    A README for a firmware-only project (e.g. Babydriver, MU, bootloader, CAN explorer) should answer the following questions:
+        - What is it?
+        - What problem does it solve?
+        - How do I use it? (with usage examples / example commands, etc)
+        - How does it work? (architectural overview)
+    A README for a board project (powering a hardware board, e.g. power distribution, centre console, charger, BMS carrier) should answer the following questions:
+        - What is the purpose of the board?
+        - What are all the things that the firmware needs to do?
+        - How does it fit into the overall system?
+        - How does it work? (architectural overview, e.g. what each module's purpose is or how data flows through the firmware)
+-->
+# fw_103
+

--- a/projects/fw_103/rules.mk
+++ b/projects/fw_103/rules.mk
@@ -1,0 +1,9 @@
+# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
+# Pre-defined:
+# $(T)_SRC_ROOT: $(T)_DIR/src
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
+
+# Specify the libraries you want to include
+$(T)_DEPS := ms-common

--- a/projects/fw_103/src/main.c
+++ b/projects/fw_103/src/main.c
@@ -1,0 +1,59 @@
+#include <stdint.h>  // for integer types
+
+#include "adc.h"
+#include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"  // interrupts are required for soft timers
+#include "log.h"        // for printing
+#include "wait.h"       // for wait function
+
+GpioAddress adc_addr = {
+  .port = GPIO_PORT_A,
+  .pin = 6,
+};
+
+static void prv_read_adc(const GpioAddress *btn_addr_ptr, void *context) {
+  uint16_t adc_data = 0;
+  if (adc_read_converted_pin(adc_addr, &adc_data) == STATUS_CODE_OK) {
+    LOG_DEBUG("ADC data: %d\n", adc_data);
+  } else {
+    LOG_DEBUG("Failed to read adc data");
+  }
+}
+
+int main(void) {
+  gpio_init();
+  gpio_it_init();
+  interrupt_init();
+
+  GpioAddress btn_addr = {
+    .port = GPIO_PORT_B,
+    .pin = 2,
+  };
+  GpioSettings adc_gpio_settings = {
+    .direction = GPIO_DIR_IN,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_ANALOG,
+  };
+  GpioSettings btn_gpio_settings = {
+    .direction = GPIO_DIR_IN,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_PULLDOWN,
+  };
+
+  gpio_init_pin(&adc_addr, &adc_gpio_settings);
+  gpio_init_pin(&btn_addr, &btn_gpio_settings);
+  adc_init(ADC_MODE_SINGLE);
+
+  adc_set_channel_pin(adc_addr, true);
+
+  InterruptSettings settings = { .priority = INTERRUPT_PRIORITY_NORMAL,
+                                 .type = INTERRUPT_TYPE_INTERRUPT };
+  gpio_it_register_interrupt(&btn_addr, &settings, INTERRUPT_EDGE_FALLING, prv_read_adc, NULL);
+
+  while (true) {
+    wait();  // wait till interrupt is triggered
+  }
+  return 0;
+}

--- a/projects/fw_103/src/main.c
+++ b/projects/fw_103/src/main.c
@@ -7,14 +7,14 @@
 #include "log.h"        // for printing
 #include "wait.h"       // for wait function
 
-GpioAddress adc_addr = {
+static GpioAddress s_adc_addr = {
   .port = GPIO_PORT_A,
   .pin = 6,
 };
 
 static void prv_read_adc(const GpioAddress *btn_addr_ptr, void *context) {
   uint16_t adc_data = 0;
-  if (adc_read_converted_pin(adc_addr, &adc_data) == STATUS_CODE_OK) {
+  if (adc_read_converted_pin(s_adc_addr, &adc_data) == STATUS_CODE_OK) {
     LOG_DEBUG("ADC data: %d\n", adc_data);
   } else {
     LOG_DEBUG("Failed to read adc data");
@@ -22,9 +22,9 @@ static void prv_read_adc(const GpioAddress *btn_addr_ptr, void *context) {
 }
 
 int main(void) {
+  interrupt_init();
   gpio_init();
   gpio_it_init();
-  interrupt_init();
 
   GpioAddress btn_addr = {
     .port = GPIO_PORT_B,
@@ -39,14 +39,14 @@ int main(void) {
   GpioSettings btn_gpio_settings = {
     .direction = GPIO_DIR_IN,
     .state = GPIO_STATE_LOW,
-    .resistor = GPIO_RES_PULLDOWN,
+    .resistor = GPIO_RES_NONE,
   };
 
-  gpio_init_pin(&adc_addr, &adc_gpio_settings);
+  gpio_init_pin(&s_adc_addr, &adc_gpio_settings);
   gpio_init_pin(&btn_addr, &btn_gpio_settings);
   adc_init(ADC_MODE_SINGLE);
 
-  adc_set_channel_pin(adc_addr, true);
+  adc_set_channel_pin(s_adc_addr, true);
 
   InterruptSettings settings = { .priority = INTERRUPT_PRIORITY_NORMAL,
                                  .type = INTERRUPT_TYPE_INTERRUPT };


### PR DESCRIPTION
FW 103 Homework

# Part 1 - Schematics and datasheets scavenger hunt
## Datasheet scavenger hunt.

| Question      | Answer |
| ----------- | ----------- |
| What bit in what register should be set on the MCP2515 CAN controller to enable one-shot mode?      | `CANCTRL[3]` |
| In the MCP2515, what are the 3 bytes you’d send over spi if you wanted to write 0x17 to register 0x0f?   | Format is ` WRITE, ADDR_BYTE, DATA_BYTE`. This becomes `0x02 0x0f 0x17`        |
| What is the digital output code (16 bits) for the MCP3427 when the input voltage is 0 | `0000000000000000` |
| What is the first Opcode byte for to start a conversion on the  ADS1259 | In binary, `0000 100x` |
| What is the address (hex) for GPIO in the MCP23008? | `0x09` |
| What are the fault codes for the LTC6811 when a fault is detected in bits 15-12? | `0b1XXX` |

## Schematic scavenger hunt.

| Question      | Answer |
| ----------- | ----------- |
|On the MSXIV power select board, what port and pin should be set to what state to shut down the LTC4417? | `PB15`, pulled low |
|On the MSXIV pedal board, does the controller board talk to the ADC via SPI, CAN, I2C, or UART? | `I2C` |
|What communication protocol is used by the MSXIV BMS carrier to communicate with the AFE and current sense board? | `SPI` |
|What port and pin are used for the MSXIV CAN interrupt for the charger interface board? | `PA8` |
|What port and pin control the horn in the MSXIV steering wheel board? | `PB1` |
|What protocol is used by the MSXIV MCI to communicate with the MCP2515? What ports and pins does this use? | `SPI`, `PB` `pins 12-15` |

# Part 2 - Buttons and ADCs
Please see FW_103 project code in PR.