### PR TITLE
[FWXV-15] Implement client-side Ping operation for CAN bootloader

### DIFF
--- a/projects/bootloader/scripts/ping.py
+++ b/projects/bootloader/scripts/ping.py
@@ -1,0 +1,101 @@
+"""This script handles the client side ping protocol"""
+
+# pylint: disable=W0612
+
+# Simple life check. The client sends out a list of IDs, or none to ping all boards
+# on the network.
+# Each board sends back a message with its ID if it’s in the bootloader
+# and ready to receive commands.
+
+import time
+import can
+
+from can_datagram import Datagram, DatagramSender, DatagramListener
+
+STATUS_CODE_OK = 0
+
+CLIENT_ID = 0
+
+PING_TYPE_ID = 3
+PING_DATA = [] # no data
+
+# For testing purposes
+RESPONSE_DATAGRAM_TYPE_ID = 4
+RESPONSE_DATAGRAM_NODE_IDS = [CLIENT_ID]
+TEST_NODE_IDS = [0,1,2,3] # Some board IDs for testing
+
+def ping(node_ids, sender: DatagramSender):
+    """Ping Protocol"""
+
+    # Avoids mutating outside object
+    node_ids_copy = set(node_ids)
+
+    recv_boards_statuses = {} # wheter or not 'in bootloader'
+    received_all_boards = False
+
+    pinging_all_boards = False
+    if node_ids == [0]:
+        pinging_all_boards = True
+
+    if not pinging_all_boards:
+        # init recv_boards_statuses to flag boards as 'not in bootloader'
+        for board_id in node_ids:
+            recv_boards_statuses[board_id] = False
+
+    # Nested to have access to above variables
+    def trigger_callback(msg, board_id):
+        """Listener callback that pairs board_ids with their status"""
+        nonlocal received_all_boards
+        nonlocal recv_boards_statuses
+
+        # Mocks controller board response datagrams
+        # Only runs when testing ('receive_own_messages' is true)
+        if msg.datagram_type_id == PING_TYPE_ID:
+            if pinging_all_boards:
+                # 'All' boards need to respond
+                for node_id in TEST_NODE_IDS:
+                    mock_message = Datagram(
+                        datagram_type_id=RESPONSE_DATAGRAM_TYPE_ID,
+                        node_ids=RESPONSE_DATAGRAM_NODE_IDS,
+                        data=bytearray([node_id]))
+                    sender.send(mock_message, node_id)
+            else:
+                # only the boards requested need to respond
+                for node_id in node_ids:
+                    if node_id == 6:
+                        # Mock that board 6 is not in bootloader
+                        continue
+                    mock_message = Datagram(
+                        datagram_type_id=RESPONSE_DATAGRAM_TYPE_ID,
+                        node_ids=RESPONSE_DATAGRAM_NODE_IDS,
+                        data=bytearray([node_id]))
+                    sender.send(mock_message, node_id)
+
+        elif msg.datagram_type_id == RESPONSE_DATAGRAM_TYPE_ID:
+            # To satisfy while loop condition
+            if not pinging_all_boards:
+                node_ids_copy.remove(board_id)
+                if len(node_ids_copy) == 0:
+                    received_all_boards=True
+        else:
+            raise Exception("Ping Failed - Unknown Datagram ID")
+
+        # Verify data from controller board, and record as 'in bootloader'
+        data = int.from_bytes(msg.data, "little")
+        if data == board_id:
+            recv_boards_statuses[board_id] = True
+
+    listener = DatagramListener(trigger_callback)
+    notifier = can.Notifier(sender.bus, [listener])
+    message = Datagram(
+        datagram_type_id=PING_TYPE_ID,
+        node_ids=list(node_ids_copy),
+        data=bytearray(PING_DATA))
+
+    sender.send(message)
+
+    timeout = time.time() + 2
+    while not received_all_boards:
+        if time.time() > timeout:
+            break
+    return recv_boards_statuses

--- a/projects/bootloader/scripts/test_ping.py
+++ b/projects/bootloader/scripts/test_ping.py
@@ -1,0 +1,39 @@
+"""This Module Tests functions in ping.py"""
+
+import unittest
+
+from can_datagram import DatagramSender
+from ping import ping
+
+STATUS_CODE_OK = 0
+
+TEST_CHANNEL = "vcan0"
+
+TEST_NODE_IDS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+TEST_EXPECTED_STATUSES = {
+    0: True,
+    1: True,
+    2: True,
+    3: True,
+    4: True,
+    5: True,
+    6: False, # Mock controller board 6 as 'not in bootloader'
+    7: True,
+    8: True,
+    9: True,
+    10:True,
+}
+
+class TestPing(unittest.TestCase):
+    """Test Ping functions"""
+
+    def test_ping_specific(self):
+        """Tests the ping function by pinging specific ids"""
+
+        sender = DatagramSender(channel=TEST_CHANNEL, receive_own_messages=True)
+        recv_boards_statuses = ping(TEST_NODE_IDS, sender)
+        self.assertEqual(recv_boards_statuses, TEST_EXPECTED_STATUSES)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/projects/bootloader/scripts/test_ping_all.py
+++ b/projects/bootloader/scripts/test_ping_all.py
@@ -1,0 +1,32 @@
+"""This Module Tests functions in ping.py"""
+
+import unittest
+
+from can_datagram import DatagramSender
+from ping import ping
+
+STATUS_CODE_OK = 0
+
+TEST_CHANNEL = "vcan0"
+
+TEST_NODE_IDS = [0]
+
+TEST_EXPECTED_STATUSES = {
+    0: True,
+    1: True,
+    2: True,
+    3: True,
+}
+
+class TestPing(unittest.TestCase):
+    """Test Ping functions"""
+
+    def test_ping_all(self):
+        """Tests the ping function by pinging all ids implicitly"""
+
+        sender = DatagramSender(channel=TEST_CHANNEL, receive_own_messages=True)
+        recv_boards_statuses = ping(TEST_NODE_IDS, sender)
+        self.assertEqual(recv_boards_statuses, TEST_EXPECTED_STATUSES)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implement the Python/client side of the bootloader ping operation using the CAN datagram library.

- `test_ping.py` tests ping functionality by passing specific controller board IDs
- `test_ping_all.py` tests ping functionality of pinging all controller boards

To run these tests, you can do something like `python3 test_ping.py`.  Running the tests requires the python `can` libraries and a virtual can interface:
```bash
sudo apt install python3-can # for Python 3.x  

sudo modprobe vcan
sudo ip link add dev vcan0 type vcan
sudo ip link set up vcan0
```